### PR TITLE
.github: test npm sticky disk

### DIFF
--- a/.github/workflows/supabase-demo.yaml
+++ b/.github/workflows/supabase-demo.yaml
@@ -1,0 +1,67 @@
+name: Start supabase with Sticky Disk
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+permissions:
+  packages: read
+  contents: read
+  id-token: write # This is required for requesting the JWT
+
+jobs:
+  github_supabase:
+    name: Run Supabase without Sticky Disk
+    runs-on: blacksmith-staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: useblacksmith/setup-node@v4
+        with:
+          node-version: 18
+      - name: Run Supabase
+        run: |
+          time npx -y supabase start
+          npx supabase db reset --debug
+          echo "Supabase is running at http://localhost:54323"
+          echo "API URL: http://localhost:54321"
+          echo "DB URL: postgresql://postgres:postgres@localhost:54322/postgres"
+
+  stickydisk_supabase:
+    name: Run Supabase with Sticky Disk
+    runs-on: blacksmith-staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: useblacksmith/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Setup sticky disk for ~/.npm
+        uses: useblacksmith/stickydisk@main
+        with:
+            key: "npm"
+            path: "~/.npm"
+
+      - name: Setup sticky disk for ./node_modules
+        uses: useblacksmith/stickydisk@main
+        with:
+            key: "node_modules"
+            path: "./node_modules"
+
+      - name: Setup sticky disk for /var/lib/docker
+        uses: useblacksmith/stickydisk@main
+        with:
+            key: "docker-data"
+            path: "/var/lib/docker"
+
+      - name: Run Supabase
+        run: |
+          time npx -y supabase start
+          npx supabase db reset --debug
+          echo "Supabase is running at http://localhost:54323"
+          echo "API URL: http://localhost:54321"
+          echo "DB URL: postgresql://postgres:postgres@localhost:54322/postgres"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,57 @@
+# A string used to distinguish different Supabase projects on the same host. Defaults to the working
+# directory name when running `supabase init`.
+project_id = "stickydisk-demo"
+
+[api]
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. public and storage are always included.
+schemas = ["public", "storage"]
+# Extra schemas to add to the search_path of every request. public is always included.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 15
+
+[studio]
+# Port to use for Supabase Studio.
+port = 54323
+
+[auth]
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://localhost:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://localhost:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 seconds (one
+# week).
+jwt_expiry = 3600
+# Allow/disallow new user signups to your project.
+enable_signup = true
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = true
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+
+[storage]
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB" 

--- a/supabase/migrations/20231214000000_initial_schema.sql
+++ b/supabase/migrations/20231214000000_initial_schema.sql
@@ -1,0 +1,25 @@
+-- Create a todos table
+CREATE TABLE todos (
+    id BIGSERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    completed BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Enable Row Level Security
+ALTER TABLE todos ENABLE ROW LEVEL SECURITY;
+
+-- Create a trigger to update the updated_at column
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_todos_updated_at
+    BEFORE UPDATE ON todos
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column(); 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,5 @@
+INSERT INTO todos (title, completed) VALUES
+    ('Buy groceries', false),
+    ('Walk the dog', true),
+    ('Learn Supabase', false),
+    ('Build a demo app', false); 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add GitHub Actions workflow to test Supabase with and without sticky disk, including configuration and SQL scripts for setup.
> 
>   - **GitHub Actions Workflow**:
>     - Adds `.github/workflows/supabase-demo.yaml` to test Supabase with and without sticky disk.
>     - `github_supabase` job runs Supabase without sticky disk on `blacksmith-staging`.
>     - `stickydisk_supabase` job runs Supabase with sticky disk, setting up sticky disk for `~/.npm`, `./node_modules`, and `/var/lib/docker`.
>   - **Supabase Configuration**:
>     - Adds `config.toml` to configure Supabase API, database, studio, and storage settings.
>   - **Database Setup**:
>     - Adds `migrations/20231214000000_initial_schema.sql` to create `todos` table with row-level security and update trigger.
>     - Adds `seed.sql` to insert initial data into `todos` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fstickydisk&utm_source=github&utm_medium=referral)<sup> for 9e93c389fc59fcbd13a802db99390fada0b0909b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->