### PR TITLE
main: maintain runner perms when mounting a stickydisk

### DIFF
--- a/.github/workflows/bump-tag.yaml
+++ b/.github/workflows/bump-tag.yaml
@@ -1,0 +1,22 @@
+name: Bump Tag
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Bump v1 tag
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f v1
+          git push origin v1 -f

--- a/dist/index.js
+++ b/dist/index.js
@@ -36229,11 +36229,13 @@ async function maybeFormatBlockDevice(device) {
     try {
         // Check if device is formatted with ext4
         try {
+            // Need sudo for blkid as it requires root to read block device metadata
             const { stdout } = await execAsync(`sudo blkid -o value -s TYPE ${device}`);
             if (stdout.trim() === 'ext4') {
                 core.debug(`Device ${device} is already formatted with ext4`);
                 try {
-                    // Run resize2fs to ensure filesystem uses full block device
+                    // Need sudo for resize2fs as it requires root to modify block device
+                    // This operation preserves existing filesystem ownership and permissions
                     await execAsync(`sudo resize2fs -f ${device}`);
                     core.debug(`Resized ext4 filesystem on ${device}`);
                 }
@@ -36249,9 +36251,13 @@ async function maybeFormatBlockDevice(device) {
             // blkid returns non-zero if no filesystem found, which is fine
             core.debug(`No filesystem found on ${device}, will format it`);
         }
-        // Format device with ext4
+        // Format device with ext4, setting default ownership to current user.
         core.debug(`Formatting device ${device} with ext4`);
-        await execAsync(`sudo mkfs.ext4 -m0 -Enodiscard,lazy_itable_init=1,lazy_journal_init=1 -F ${device}`);
+        // Need sudo for mkfs.ext4 as it requires root to format block device
+        // -m0: Disable reserved blocks (all space available to non-root users)
+        // root_owner=$(id -u):$(id -g): Sets filesystem root directory owner to current (runner) user
+        // This ensures the filesystem is owned by runner user from the start
+        await execAsync(`sudo mkfs.ext4 -m0 -E root_owner=$(id -u):$(id -g) -Enodiscard,lazy_itable_init=1,lazy_journal_init=1 -F ${device}`);
         core.debug(`Successfully formatted ${device} with ext4`);
         return device;
     }
@@ -36269,8 +36275,13 @@ async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller
     const exposeId = stickyDiskResponse.expose_id;
     clearTimeout(timeoutId);
     await maybeFormatBlockDevice(device);
-    await execAsync(`sudo mkdir -p ${stickyDiskPath}`);
+    // Create mount point WITHOUT sudo so the directory is owned by runner user
+    // This is important because the mount point ownership affects access when nothing is mounted.
+    await execAsync(`mkdir -p ${stickyDiskPath}`);
+    // Mount the device with default options
     await execAsync(`sudo mount ${device} ${stickyDiskPath}`);
+    // After mounting, set the ownership of the mount point
+    await execAsync(`sudo chown $(id -u):$(id -g) ${stickyDiskPath}`);
     core.debug(`${device} has been mounted to ${stickyDiskPath} with expose ID ${exposeId}`);
     return { device, exposeId };
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Maintain runner permissions when mounting stickydisk by setting filesystem and mount point ownership, and add GitHub Actions workflow for tag management.
> 
>   - **Filesystem Formatting**:
>     - In `maybeFormatBlockDevice()`, use `sudo mkfs.ext4` with `-E root_owner=$(id -u):$(id -g)` to set filesystem ownership to runner user.
>     - Ensure `resize2fs` operation preserves existing filesystem ownership and permissions.
>   - **Mounting**:
>     - In `mountStickyDisk()`, create mount point without `sudo` to ensure runner user ownership.
>     - Use `sudo chown $(id -u):$(id -g)` after mounting to set mount point ownership to runner user.
>   - **GitHub Actions**:
>     - Add `bump-tag.yaml` workflow to bump `v1` tag on `workflow_dispatch` and `pull_request` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fstickydisk&utm_source=github&utm_medium=referral)<sup> for d29289de91715f4ec28f1750f337b9e0fca8fab4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->