### PR TITLE
src: add sync before umount

### DIFF
--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -36333,7 +36333,9 @@ async function run() {
             core.debug(`${stickyDiskPath} is not mounted, skipping unmount`);
             return;
         }
-        // First try to unmount with retries
+        // Ensure all pending writes are flushed to disk before unmounting.
+        await execAsync('sync');
+        // Unmount with retries.
         for (let attempt = 1; attempt <= 10; attempt++) {
             try {
                 await execAsync(`sudo umount ${stickyDiskPath}`);

--- a/src/post.ts
+++ b/src/post.ts
@@ -80,7 +80,10 @@ async function run(): Promise<void> {
       return;
     }
 
-    // First try to unmount with retries
+    // Ensure all pending writes are flushed to disk before unmounting.
+    await execAsync('sync');
+
+    // Unmount with retries.
     for (let attempt = 1; attempt <= 10; attempt++) {
       try {
         await execAsync(`sudo umount ${stickyDiskPath}`);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `sync` command in `run()` in `post.ts` to flush writes before unmounting a disk.
> 
>   - **Behavior**:
>     - Adds `await execAsync('sync');` in `run()` in `post.ts` to flush pending writes before unmounting a disk.
>   - **Comments**:
>     - Updates comment in `run()` to reflect the addition of the `sync` command before unmounting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fstickydisk&utm_source=github&utm_medium=referral)<sup> for a85354cb43244cb135088514ddb1ab0d07c13a95. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->