### PR TITLE
src: increase timeout to the same as build-push-action

### DIFF
--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -36360,7 +36360,7 @@ async function run() {
     }
     catch (error) {
         if (error instanceof Error) {
-            core.error(`Failed to cleanup and commit sticky disk at ${stickyDiskPath}: ${error}`);
+            core.warning(`Failed to cleanup and commit sticky disk at ${stickyDiskPath}: ${error}`);
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "root",
       "dependencies": {
         "@actions/core": "^1.10.1",
-        "@buf/blacksmith_vm-agent.connectrpc_es": "^1.6.1-20241220192643-e85a9caa965d.2",
+        "@buf/blacksmith_vm-agent.connectrpc_es": "^1.6.1-20250209182455-7d83cfb8ddb1.2",
         "@bufbuild/connect": "^0.13.0",
         "@bufbuild/connect-web": "^0.13.0",
         "@bufbuild/protobuf": "^1.4.2",
@@ -598,17 +598,38 @@
       "license": "MIT"
     },
     "node_modules/@buf/blacksmith_vm-agent.bufbuild_es": {
-      "version": "1.10.0-20241220192643-e85a9caa965d.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/blacksmith_vm-agent.bufbuild_es/-/blacksmith_vm-agent.bufbuild_es-1.10.0-20241220192643-e85a9caa965d.1.tgz",
+      "version": "1.10.0-20250209182455-7d83cfb8ddb1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/blacksmith_vm-agent.bufbuild_es/-/blacksmith_vm-agent.bufbuild_es-1.10.0-20250209182455-7d83cfb8ddb1.1.tgz",
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250203201857-83c0f6c19b2f.1"
+      },
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@buf/blacksmith_vm-agent.connectrpc_es": {
-      "version": "1.6.1-20241220192643-e85a9caa965d.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/blacksmith_vm-agent.connectrpc_es/-/blacksmith_vm-agent.connectrpc_es-1.6.1-20241220192643-e85a9caa965d.2.tgz",
+      "version": "1.6.1-20250209182455-7d83cfb8ddb1.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/blacksmith_vm-agent.connectrpc_es/-/blacksmith_vm-agent.connectrpc_es-1.6.1-20250209182455-7d83cfb8ddb1.2.tgz",
       "dependencies": {
-        "@buf/blacksmith_vm-agent.bufbuild_es": "1.10.0-20241220192643-e85a9caa965d.1"
+        "@buf/blacksmith_vm-agent.bufbuild_es": "1.10.0-20250209182455-7d83cfb8ddb1.1",
+        "@buf/googleapis_googleapis.connectrpc_es": "1.6.1-20250203201857-83c0f6c19b2f.2"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.6.1"
+      }
+    },
+    "node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.10.0-20250203201857-83c0f6c19b2f.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.10.0-20250203201857-83c0f6c19b2f.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@buf/googleapis_googleapis.connectrpc_es": {
+      "version": "1.6.1-20250203201857-83c0f6c19b2f.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.6.1-20250203201857-83c0f6c19b2f.2.tgz",
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250203201857-83c0f6c19b2f.1"
       },
       "peerDependencies": {
         "@connectrpc/connect": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@buf/blacksmith_vm-agent.connectrpc_es": "^1.6.1-20241220192643-e85a9caa965d.2",
+    "@buf/blacksmith_vm-agent.connectrpc_es": "^1.6.1-20250209182455-7d83cfb8ddb1.2",
     "@bufbuild/connect": "^0.13.0",
     "@bufbuild/connect-web": "^0.13.0",
     "@bufbuild/protobuf": "^1.4.2",

--- a/src/post.ts
+++ b/src/post.ts
@@ -106,7 +106,7 @@ async function run(): Promise<void> {
     }
   } catch (error) {
     if (error instanceof Error) {
-      core.error(`Failed to cleanup and commit sticky disk at ${stickyDiskPath}: ${error}`);
+      core.warning(`Failed to cleanup and commit sticky disk at ${stickyDiskPath}: ${error}`);
     }
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increased sticky disk mount timeout and changed error handling to warnings in `src/main.ts` and `src/post.ts`, and updated a dependency version in `package.json`.
> 
>   - **Timeout Increase**:
>     - In `src/main.ts`, increased timeout for `mountStickyDisk()` from 15000ms to `stickyDiskTimeoutMs` (45000ms).
>   - **Error Handling**:
>     - Changed `core.error` to `core.warning` in `maybeFormatBlockDevice()` and `run()` in `src/main.ts`.
>     - Changed `core.error` to `core.warning` in `run()` in `src/post.ts`.
>   - **Dependencies**:
>     - Updated `@buf/blacksmith_vm-agent.connectrpc_es` version in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fstickydisk&utm_source=github&utm_medium=referral)<sup> for 5175c4c79a1fa919f6f7b264f9896fe16e82007b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->