### PR TITLE
use the env var for sticky disk grpc port

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36291,9 +36291,10 @@ const StickyDiskService = {
 
 
 function createStickyDiskClient() {
+    const port = process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT || "5557";
     const transport = createGrpcTransport({
-        baseUrl: 'http://192.168.127.1:5557',
-        httpVersion: '2',
+        baseUrl: `http://192.168.127.1:${port}`,
+        httpVersion: "2",
     });
     return createClient(StickyDiskService, transport);
 }

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -36291,9 +36291,10 @@ const StickyDiskService = {
 
 
 function createStickyDiskClient() {
+    const port = process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT || "5557";
     const transport = createGrpcTransport({
-        baseUrl: 'http://192.168.127.1:5557',
-        httpVersion: '2',
+        baseUrl: `http://192.168.127.1:${port}`,
+        httpVersion: "2",
     });
     return createClient(StickyDiskService, transport);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,10 +3,11 @@ import { createGrpcTransport } from "@connectrpc/connect-node";
 import { StickyDiskService } from "@buf/blacksmith_vm-agent.connectrpc_es/stickydisk/v1/stickydisk_connect";
 
 export function createStickyDiskClient() {
+  const port = process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT || "5557";
   const transport = createGrpcTransport({
-    baseUrl: 'http://192.168.127.1:5557',
-    httpVersion: '2',
+    baseUrl: `http://192.168.127.1:${port}`,
+    httpVersion: "2",
   });
 
   return createClient(StickyDiskService, transport);
-} 
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `createStickyDiskClient` now uses an environment variable for the gRPC port, defaulting to `5557`.
> 
>   - **Behavior**:
>     - `createStickyDiskClient` in `utils.ts` now uses `process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT` for the gRPC port, defaulting to `5557` if not set.
>     - Allows dynamic configuration of the gRPC port via environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fstickydisk&utm_source=github&utm_medium=referral)<sup> for 617cc462d6e12f547c72453b44b09a6fa55a4e70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->