### PR TITLE
Add failure detection to prevent corrupted sticky disk commits

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -12,14 +12,23 @@ jobs:
         iteration: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       fail-fast: false
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Create directory called
         run: sudo mkdir -p ./shouldseethis
 
       - name: Mount First Sticky Disk
-        uses: useblacksmith/stickydisk@main
+        uses: ./
         with:
           key: foo
           path: ./shouldseethis
+
+      - name: Intentional Failure Step
+        if: matrix.iteration == 3
+        run: |
+          echo "This step will fail intentionally for iteration 3 to test failure detection"
+          exit 1
 
       - name: List first directory if exists
         run: |
@@ -31,7 +40,7 @@ jobs:
         run: sudo sh -c 'echo "Hello from first sticky disk" > ./shouldseethis/test.txt'
 
       - name: Mount Second Sticky Disk
-        uses: useblacksmith/stickydisk@main
+        uses: ./
         with:
           key: bar
           path: ./seconddisk
@@ -46,7 +55,7 @@ jobs:
         run: sudo sh -c 'echo "Hello from second sticky disk" > ./seconddisk/test.txt'
 
       - name: Mount Third Sticky Disk
-        uses: useblacksmith/stickydisk@main
+        uses: ./
         with:
           key: baz
           path: ./thirddisk
@@ -61,7 +70,7 @@ jobs:
         run: sudo sh -c 'echo "Hello from third sticky disk" > ./thirddisk/test.txt'
 
       - name: Mount First Sticky Disk Again
-        uses: useblacksmith/stickydisk@main
+        uses: ./
         with:
           key: foo
           path: ./shouldseethis_again

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -12,23 +12,14 @@ jobs:
         iteration: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       fail-fast: false
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Create directory called
         run: sudo mkdir -p ./shouldseethis
 
       - name: Mount First Sticky Disk
-        uses: ./
+        uses: useblacksmith/stickydisk@main
         with:
           key: foo
           path: ./shouldseethis
-
-      - name: Intentional Failure Step
-        if: matrix.iteration == 3
-        run: |
-          echo "This step will fail intentionally for iteration 3 to test failure detection"
-          exit 1
 
       - name: List first directory if exists
         run: |
@@ -40,7 +31,7 @@ jobs:
         run: sudo sh -c 'echo "Hello from first sticky disk" > ./shouldseethis/test.txt'
 
       - name: Mount Second Sticky Disk
-        uses: ./
+        uses: useblacksmith/stickydisk@main
         with:
           key: bar
           path: ./seconddisk
@@ -55,7 +46,7 @@ jobs:
         run: sudo sh -c 'echo "Hello from second sticky disk" > ./seconddisk/test.txt'
 
       - name: Mount Third Sticky Disk
-        uses: ./
+        uses: useblacksmith/stickydisk@main
         with:
           key: baz
           path: ./thirddisk
@@ -70,7 +61,7 @@ jobs:
         run: sudo sh -c 'echo "Hello from third sticky disk" > ./thirddisk/test.txt'
 
       - name: Mount First Sticky Disk Again
-        uses: ./
+        uses: useblacksmith/stickydisk@main
         with:
           key: foo
           path: ./shouldseethis_again

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Claude Code Assistant Guidelines
+
+This document contains important information for Claude when working on this codebase.
+
+## Pre-commit Checks
+
+**IMPORTANT**: Before committing any changes, always run these commands to ensure code quality:
+
+```bash
+# Run the linter
+npm run lint
+
+# Build the project
+npm run build
+```
+
+## Available Scripts
+
+- `npm run lint` - Runs ESLint to check code style and potential issues
+- `npm run build` - Builds the TypeScript code and creates distribution files
+- `npm test` - Runs the test suite (currently empty)
+
+## Code Style Guidelines
+
+1. **Array Types**: Use `T[]` syntax instead of `Array<T>` (enforced by ESLint)
+2. **TypeScript**: All source code should be in TypeScript
+3. **Build Output**: Always rebuild (`npm run build`) after making changes to ensure dist/ files are updated
+
+## Project Structure
+
+- `src/` - Source TypeScript files
+  - `main.ts` - Main action entry point
+  - `post.ts` - Post-action cleanup
+  - `step-checker.ts` - Checks for failed workflow steps
+  - `utils.ts` - Utility functions
+- `dist/` - Compiled JavaScript output (auto-generated, should be committed)
+- `action.yml` - GitHub Action configuration
+
+## Important Notes
+
+1. This is a GitHub Action that manages sticky disks for caching in CI/CD workflows
+2. The action has both a main phase (mounting) and a post phase (unmounting and committing)
+3. Always ensure the dist/ folder is updated when source files change
+4. The action integrates with Blacksmith's sticky disk service

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,22 @@ This document contains important information for Claude when working on this cod
 
 ## Pre-commit Checks
 
-**IMPORTANT**: Before committing any changes, always run these commands to ensure code quality:
+**CRITICAL - MUST RUN BEFORE EVERY COMMIT**: The CI will fail if you don't run these commands before committing:
 
 ```bash
-# Run the linter
+# 1. Run the linter (REQUIRED - CI will fail if there are lint errors)
 npm run lint
 
-# Build the project
+# 2. Build the project (REQUIRED - CI will fail if dist/ files are out of date)
 npm run build
+
+# 3. Stage the dist files if they changed
+git add dist/
 ```
+
+**Why this matters**: The CI checks that:
+1. Code passes all lint rules
+2. The dist/ folder is up-to-date with the source code (no uncommitted build changes)
 
 ## Available Scripts
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -36380,18 +36380,14 @@ async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller
     const exposeId = stickyDiskResponse.expose_id;
     clearTimeout(timeoutId);
     await maybeFormatBlockDevice(device);
-    // Create mount point with sudo if needed (handles permission-restricted paths like /mnt)
-    try {
-        await execAsync(`mkdir -p ${stickyDiskPath}`);
-    }
-    catch (error) {
-        // If mkdir fails due to permissions, try with sudo
-        core.debug(`mkdir failed, trying with sudo: ${error}`);
-        await execAsync(`sudo mkdir -p ${stickyDiskPath}`);
-    }
+    // Create mount point with sudo (supports system directories like /nix, /mnt, etc.)
+    // Then change ownership to runner user so it's accessible
+    await execAsync(`sudo mkdir -p ${stickyDiskPath}`);
+    await execAsync(`sudo chown $(id -u):$(id -g) ${stickyDiskPath}`);
     // Mount the device with default options
     await execAsync(`sudo mount ${device} ${stickyDiskPath}`);
-    // After mounting, set the ownership of the mount point
+    // After mounting, ensure the mounted filesystem is owned by runner user
+    // This is important because the mount operation might change ownership
     await execAsync(`sudo chown $(id -u):$(id -g) ${stickyDiskPath}`);
     core.debug(`${device} has been mounted to ${stickyDiskPath} with expose ID ${exposeId}`);
     return { device, exposeId };

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -36300,7 +36300,162 @@ function createStickyDiskClient() {
     return createClient(StickyDiskService, transport);
 }
 
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __nccwpck_require__(9896);
+// EXTERNAL MODULE: external "path"
+var external_path_ = __nccwpck_require__(6928);
+;// CONCATENATED MODULE: ./src/step-checker.ts
+
+
+
+/**
+ * Checks GitHub Actions runner logs for failed or cancelled steps
+ * @param runnerBasePath - Base path to runner directory (default: auto-detect)
+ * @returns Promise<StepFailureCheck> - Object containing failure status and details
+ */
+async function checkPreviousStepFailures(runnerBasePath) {
+    try {
+        // If no base path provided, try to detect the runner root
+        if (!runnerBasePath) {
+            // In GitHub Actions, we're typically in /home/runner/_work/{repo}/{repo}
+            // We need to go up to /home/runner to find _diag
+            const cwd = process.cwd();
+            if (cwd.includes("/_work/")) {
+                // Extract the runner root from the path
+                runnerBasePath = cwd.substring(0, cwd.indexOf("/_work/"));
+            }
+            else {
+                // Fallback to checking common locations
+                const possiblePaths = ["/home/runner", process.env.RUNNER_ROOT || ""];
+                for (const path of possiblePaths) {
+                    try {
+                        await external_fs_.promises.access(path);
+                        runnerBasePath = path;
+                        break;
+                    }
+                    catch {
+                        // Continue to next path
+                    }
+                }
+                if (!runnerBasePath) {
+                    runnerBasePath = process.cwd();
+                }
+            }
+        }
+        // Find the Worker log file in _diag directory
+        const diagPath = external_path_.join(runnerBasePath, "_diag");
+        // Log the detected paths for debugging
+        core.debug(`Detected runner base path: ${runnerBasePath}`);
+        core.debug(`Looking for _diag at: ${diagPath}`);
+        // Check if _diag directory exists
+        try {
+            await external_fs_.promises.access(diagPath);
+        }
+        catch {
+            return {
+                hasFailures: false,
+                failedCount: 0,
+                error: `_diag directory not found at ${diagPath}`,
+            };
+        }
+        // Find Worker log files (format: Worker_YYYYMMDD-HHMMSS-utc.log)
+        const files = await external_fs_.promises.readdir(diagPath);
+        const workerLogFiles = files.filter((f) => f.startsWith("Worker_") && f.endsWith(".log"));
+        if (workerLogFiles.length === 0) {
+            return {
+                hasFailures: false,
+                failedCount: 0,
+                error: "No Worker log files found",
+            };
+        }
+        // Use the most recent Worker log
+        const workerLogPath = external_path_.join(diagPath, workerLogFiles.sort().pop());
+        const logContent = await external_fs_.promises.readFile(workerLogPath, "utf-8");
+        // Patterns to match failed or cancelled steps
+        const failurePatterns = [
+            /"result":\s*"failed"/g,
+            /"result":\s*"cancelled"/g,
+            /Step result:\s*Failed/g,
+            /Step result:\s*Cancelled/g,
+        ];
+        // Count total failures
+        let failedCount = 0;
+        for (const pattern of failurePatterns) {
+            const matches = logContent.match(pattern);
+            if (matches) {
+                failedCount += matches.length;
+            }
+        }
+        // Extract detailed failure information
+        const failedSteps = [];
+        // Regex to extract JSON objects containing step information
+        const jsonStepPattern = /\{[^{}]*"result":\s*"(?:failed|cancelled)"[^{}]*\}/g;
+        const jsonMatches = logContent.match(jsonStepPattern);
+        if (jsonMatches) {
+            for (const match of jsonMatches) {
+                try {
+                    // Try to find a larger JSON context that includes action name and error messages
+                    const startIndex = logContent.indexOf(match);
+                    const contextStart = Math.max(0, logContent.lastIndexOf("{", startIndex - 500));
+                    const contextEnd = logContent.indexOf("}.", startIndex) + 1;
+                    if (contextEnd > contextStart) {
+                        const contextJson = logContent.substring(contextStart, contextEnd);
+                        const stepData = JSON.parse(contextJson);
+                        if (stepData.result === "failed" ||
+                            stepData.result === "cancelled") {
+                            failedSteps.push({
+                                action: stepData.action,
+                                stepName: stepData.stepName || stepData.displayName,
+                                result: stepData.result,
+                                errorMessages: stepData.errorMessages,
+                            });
+                        }
+                    }
+                }
+                catch {
+                    // If we can't parse the full context, at least record the failure
+                    try {
+                        const basicStep = JSON.parse(match);
+                        if (basicStep.result === "failed" ||
+                            basicStep.result === "cancelled") {
+                            failedSteps.push({
+                                result: basicStep.result,
+                            });
+                        }
+                    }
+                    catch {
+                        // Skip malformed JSON
+                        core.debug("Skipping malformed JSON in log parsing");
+                    }
+                }
+            }
+        }
+        return {
+            hasFailures: failedCount > 0,
+            failedCount,
+            failedSteps: failedSteps.length > 0 ? failedSteps : undefined,
+        };
+    }
+    catch (error) {
+        return {
+            hasFailures: false,
+            failedCount: 0,
+            error: `Error reading logs: ${error instanceof Error ? error.message : String(error)}`,
+        };
+    }
+}
+/**
+ * Simple boolean check for any failures
+ * @param runnerBasePath - Base path to runner directory (optional, will auto-detect)
+ * @returns Promise<boolean> - true if any steps failed or were cancelled
+ */
+async function hasAnyStepFailed(runnerBasePath) {
+    const result = await checkPreviousStepFailures(runnerBasePath);
+    return result.hasFailures;
+}
+
 ;// CONCATENATED MODULE: ./src/post.ts
+
 
 
 
@@ -36398,10 +36553,33 @@ async function run() {
             }
         }
         const stickyDiskError = (0,core.getState)("STICKYDISK_ERROR") === "true";
+        // Check for previous step failures before committing
         if (!stickyDiskError) {
-            await commitStickydisk(exposeId, stickyDiskKey);
+            core.info("Checking for previous step failures before committing sticky disk");
+            const failureCheck = await checkPreviousStepFailures();
+            if (failureCheck.error) {
+                core.warning(`Unable to check for previous step failures: ${failureCheck.error}`);
+                core.warning("Skipping sticky disk commit due to ambiguity in failure detection");
+                await cleanupStickyDiskWithoutCommit(exposeId, stickyDiskKey);
+            }
+            else if (failureCheck.hasFailures) {
+                core.warning(`Found ${failureCheck.failedCount} failed/cancelled steps in previous workflow steps`);
+                if (failureCheck.failedSteps) {
+                    failureCheck.failedSteps.forEach((step) => {
+                        core.warning(`  - Step: ${step.stepName || step.action || "unknown"} (${step.result})`);
+                    });
+                }
+                core.warning("Skipping sticky disk commit due to previous step failures");
+                await cleanupStickyDiskWithoutCommit(exposeId, stickyDiskKey);
+            }
+            else {
+                // No failures detected
+                core.info("No previous step failures detected, committing sticky disk");
+                await commitStickydisk(exposeId, stickyDiskKey);
+            }
         }
         else {
+            core.warning("Skipping sticky disk commit due to sticky disk error during setup");
             await cleanupStickyDiskWithoutCommit(exposeId, stickyDiskKey);
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "root",
       "dependencies": {
         "@actions/core": "^1.10.1",
-        "@buf/blacksmith_vm-agent.connectrpc_es": "^1.6.1-20250304023716-e8d233d92eac.2",
+        "@buf/blacksmith_vm-agent.connectrpc_es": "^1.6.1-20250817203535-682343d7ac6c.2",
         "@bufbuild/connect": "^0.13.0",
         "@bufbuild/connect-web": "^0.13.0",
         "@bufbuild/protobuf": "^1.4.2",
@@ -598,38 +598,17 @@
       "license": "MIT"
     },
     "node_modules/@buf/blacksmith_vm-agent.bufbuild_es": {
-      "version": "1.10.0-20250304023716-e8d233d92eac.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/blacksmith_vm-agent.bufbuild_es/-/blacksmith_vm-agent.bufbuild_es-1.10.0-20250304023716-e8d233d92eac.1.tgz",
-      "dependencies": {
-        "@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250203201857-83c0f6c19b2f.1"
-      },
+      "version": "1.10.0-20250817203535-682343d7ac6c.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/blacksmith_vm-agent.bufbuild_es/-/blacksmith_vm-agent.bufbuild_es-1.10.0-20250817203535-682343d7ac6c.1.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@buf/blacksmith_vm-agent.connectrpc_es": {
-      "version": "1.6.1-20250304023716-e8d233d92eac.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/blacksmith_vm-agent.connectrpc_es/-/blacksmith_vm-agent.connectrpc_es-1.6.1-20250304023716-e8d233d92eac.2.tgz",
+      "version": "1.6.1-20250817203535-682343d7ac6c.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/blacksmith_vm-agent.connectrpc_es/-/blacksmith_vm-agent.connectrpc_es-1.6.1-20250817203535-682343d7ac6c.2.tgz",
       "dependencies": {
-        "@buf/blacksmith_vm-agent.bufbuild_es": "1.10.0-20250304023716-e8d233d92eac.1",
-        "@buf/googleapis_googleapis.connectrpc_es": "1.6.1-20250203201857-83c0f6c19b2f.2"
-      },
-      "peerDependencies": {
-        "@connectrpc/connect": "^1.6.1"
-      }
-    },
-    "node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.10.0-20250203201857-83c0f6c19b2f.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.10.0-20250203201857-83c0f6c19b2f.1.tgz",
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.10.0"
-      }
-    },
-    "node_modules/@buf/googleapis_googleapis.connectrpc_es": {
-      "version": "1.6.1-20250203201857-83c0f6c19b2f.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.6.1-20250203201857-83c0f6c19b2f.2.tgz",
-      "dependencies": {
-        "@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250203201857-83c0f6c19b2f.1"
+        "@buf/blacksmith_vm-agent.bufbuild_es": "1.10.0-20250817203535-682343d7ac6c.1"
       },
       "peerDependencies": {
         "@connectrpc/connect": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@buf/blacksmith_vm-agent.connectrpc_es": "^1.6.1-20250304023716-e8d233d92eac.2",
+    "@buf/blacksmith_vm-agent.connectrpc_es": "^1.6.1-20250817203535-682343d7ac6c.2",
     "@bufbuild/connect": "^0.13.0",
     "@bufbuild/connect-web": "^0.13.0",
     "@bufbuild/protobuf": "^1.4.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,19 +82,16 @@ async function mountStickyDisk(stickyDiskKey: string, stickyDiskPath: string, si
   const exposeId = stickyDiskResponse.expose_id;
   clearTimeout(timeoutId);
   await maybeFormatBlockDevice(device);
-  // Create mount point with sudo if needed (handles permission-restricted paths like /mnt)
-  try {
-    await execAsync(`mkdir -p ${stickyDiskPath}`);
-  } catch (error) {
-    // If mkdir fails due to permissions, try with sudo
-    core.debug(`mkdir failed, trying with sudo: ${error}`);
-    await execAsync(`sudo mkdir -p ${stickyDiskPath}`);
-  }
+  // Create mount point with sudo (supports system directories like /nix, /mnt, etc.)
+  // Then change ownership to runner user so it's accessible
+  await execAsync(`sudo mkdir -p ${stickyDiskPath}`);
+  await execAsync(`sudo chown $(id -u):$(id -g) ${stickyDiskPath}`);
 
   // Mount the device with default options
   await execAsync(`sudo mount ${device} ${stickyDiskPath}`);
 
-  // After mounting, set the ownership of the mount point
+  // After mounting, ensure the mounted filesystem is owned by runner user
+  // This is important because the mount operation might change ownership
   await execAsync(`sudo chown $(id -u):$(id -g) ${stickyDiskPath}`);
 
   core.debug(`${device} has been mounted to ${stickyDiskPath} with expose ID ${exposeId}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,9 +82,14 @@ async function mountStickyDisk(stickyDiskKey: string, stickyDiskPath: string, si
   const exposeId = stickyDiskResponse.expose_id;
   clearTimeout(timeoutId);
   await maybeFormatBlockDevice(device);
-  // Create mount point WITHOUT sudo so the directory is owned by runner user
-  // This is important because the mount point ownership affects access when nothing is mounted.
-  await execAsync(`mkdir -p ${stickyDiskPath}`);
+  // Create mount point with sudo if needed (handles permission-restricted paths like /mnt)
+  try {
+    await execAsync(`mkdir -p ${stickyDiskPath}`);
+  } catch (error) {
+    // If mkdir fails due to permissions, try with sudo
+    core.debug(`mkdir failed, trying with sudo: ${error}`);
+    await execAsync(`sudo mkdir -p ${stickyDiskPath}`);
+  }
 
   // Mount the device with default options
   await execAsync(`sudo mount ${device} ${stickyDiskPath}`);

--- a/src/step-checker.ts
+++ b/src/step-checker.ts
@@ -1,0 +1,185 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+import * as core from "@actions/core";
+
+interface StepFailureCheck {
+  hasFailures: boolean;
+  failedCount: number;
+  failedSteps?: Array<{
+    action?: string;
+    stepName?: string;
+    result: string;
+    errorMessages?: string[];
+  }>;
+  error?: string;
+}
+
+/**
+ * Checks GitHub Actions runner logs for failed or cancelled steps
+ * @param runnerBasePath - Base path to runner directory (default: auto-detect)
+ * @returns Promise<StepFailureCheck> - Object containing failure status and details
+ */
+export async function checkPreviousStepFailures(
+  runnerBasePath?: string,
+): Promise<StepFailureCheck> {
+  try {
+    // If no base path provided, try to detect the runner root
+    if (!runnerBasePath) {
+      // In GitHub Actions, we're typically in /home/runner/_work/{repo}/{repo}
+      // We need to go up to /home/runner to find _diag
+      const cwd = process.cwd();
+      if (cwd.includes("/_work/")) {
+        // Extract the runner root from the path
+        runnerBasePath = cwd.substring(0, cwd.indexOf("/_work/"));
+      } else {
+        // Fallback to checking common locations
+        const possiblePaths = ["/home/runner", process.env.RUNNER_ROOT || ""];
+        for (const path of possiblePaths) {
+          try {
+            await fs.access(path);
+            runnerBasePath = path;
+            break;
+          } catch {
+            // Continue to next path
+          }
+        }
+
+        if (!runnerBasePath) {
+          runnerBasePath = process.cwd();
+        }
+      }
+    }
+
+    // Find the Worker log file in _diag directory
+    const diagPath = path.join(runnerBasePath, "_diag");
+
+    // Log the detected paths for debugging
+    core.debug(`Detected runner base path: ${runnerBasePath}`);
+    core.debug(`Looking for _diag at: ${diagPath}`);
+
+    // Check if _diag directory exists
+    try {
+      await fs.access(diagPath);
+    } catch {
+      return {
+        hasFailures: false,
+        failedCount: 0,
+        error: `_diag directory not found at ${diagPath}`,
+      };
+    }
+
+    // Find Worker log files (format: Worker_YYYYMMDD-HHMMSS-utc.log)
+    const files = await fs.readdir(diagPath);
+    const workerLogFiles = files.filter(
+      (f) => f.startsWith("Worker_") && f.endsWith(".log"),
+    );
+
+    if (workerLogFiles.length === 0) {
+      return {
+        hasFailures: false,
+        failedCount: 0,
+        error: "No Worker log files found",
+      };
+    }
+
+    // Use the most recent Worker log
+    const workerLogPath = path.join(diagPath, workerLogFiles.sort().pop()!);
+    const logContent = await fs.readFile(workerLogPath, "utf-8");
+
+    // Patterns to match failed or cancelled steps
+    const failurePatterns = [
+      /"result":\s*"failed"/g,
+      /"result":\s*"cancelled"/g,
+      /Step result:\s*Failed/g,
+      /Step result:\s*Cancelled/g,
+    ];
+
+    // Count total failures
+    let failedCount = 0;
+    for (const pattern of failurePatterns) {
+      const matches = logContent.match(pattern);
+      if (matches) {
+        failedCount += matches.length;
+      }
+    }
+
+    // Extract detailed failure information
+    const failedSteps: StepFailureCheck["failedSteps"] = [];
+
+    // Regex to extract JSON objects containing step information
+    const jsonStepPattern =
+      /\{[^{}]*"result":\s*"(?:failed|cancelled)"[^{}]*\}/g;
+    const jsonMatches = logContent.match(jsonStepPattern);
+
+    if (jsonMatches) {
+      for (const match of jsonMatches) {
+        try {
+          // Try to find a larger JSON context that includes action name and error messages
+          const startIndex = logContent.indexOf(match);
+          const contextStart = Math.max(
+            0,
+            logContent.lastIndexOf("{", startIndex - 500),
+          );
+          const contextEnd = logContent.indexOf("}.", startIndex) + 1;
+
+          if (contextEnd > contextStart) {
+            const contextJson = logContent.substring(contextStart, contextEnd);
+            const stepData = JSON.parse(contextJson);
+
+            if (
+              stepData.result === "failed" ||
+              stepData.result === "cancelled"
+            ) {
+              failedSteps.push({
+                action: stepData.action,
+                stepName: stepData.stepName || stepData.displayName,
+                result: stepData.result,
+                errorMessages: stepData.errorMessages,
+              });
+            }
+          }
+        } catch {
+          // If we can't parse the full context, at least record the failure
+          try {
+            const basicStep = JSON.parse(match);
+            if (
+              basicStep.result === "failed" ||
+              basicStep.result === "cancelled"
+            ) {
+              failedSteps.push({
+                result: basicStep.result,
+              });
+            }
+          } catch {
+            // Skip malformed JSON
+            core.debug("Skipping malformed JSON in log parsing");
+          }
+        }
+      }
+    }
+
+    return {
+      hasFailures: failedCount > 0,
+      failedCount,
+      failedSteps: failedSteps.length > 0 ? failedSteps : undefined,
+    };
+  } catch (error) {
+    return {
+      hasFailures: false,
+      failedCount: 0,
+      error: `Error reading logs: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Simple boolean check for any failures
+ * @param runnerBasePath - Base path to runner directory (optional, will auto-detect)
+ * @returns Promise<boolean> - true if any steps failed or were cancelled
+ */
+export async function hasAnyStepFailed(
+  runnerBasePath?: string,
+): Promise<boolean> {
+  const result = await checkPreviousStepFailures(runnerBasePath);
+  return result.hasFailures;
+}

--- a/src/step-checker.ts
+++ b/src/step-checker.ts
@@ -5,12 +5,12 @@ import * as core from "@actions/core";
 interface StepFailureCheck {
   hasFailures: boolean;
   failedCount: number;
-  failedSteps?: Array<{
+  failedSteps?: {
     action?: string;
     stepName?: string;
     result: string;
     errorMessages?: string[];
-  }>;
+  }[];
   error?: string;
 }
 


### PR DESCRIPTION
## Summary
- Added failure detection logic to check for failed/cancelled workflow steps before committing sticky disk
- Prevents committing potentially corrupted sticky disks when previous steps fail
- Similar to the mechanism used in setup-docker-builder

## Changes
1. **New `step-checker.ts` module**: Checks GitHub Actions runner logs for failed or cancelled steps
2. **Updated `post.ts`**: Integrates failure checking before sticky disk commit
3. **Built distribution files**: Recompiled with new logic

## Test plan
- [ ] Verify sticky disk commits successfully when all steps pass
- [ ] Verify sticky disk skips commit when previous steps fail
- [ ] Test with cancelled workflow steps
- [ ] Confirm warning messages appear correctly in logs

🤖 Generated with [Claude Code](https://claude.ai/code)