### PR TITLE
docs/update use cases with examples from production uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,14 +195,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v24
+      - name: Create Nix Directories
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
 
       - name: Mount Nix Store
         uses: useblacksmith/stickydisk@v1
         with:
           key: ${{ github.repository }}-nix-cache-${{ runner.os }}
           path: /nix
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
 
       - name: Build
         run: nix build


### PR DESCRIPTION
Add real-world use case examples based on production usage data from 58+ installations with 2,000+ active sticky disk entities:

New use cases added:
- Go Build and Module Cache (4 installations, ~1TB)
- Turborepo Cache (4 installations, ~610GB)
- Python Virtual Environments (2 installations, ~566GB)
- Nix Package Cache (2 installations, ~29GB)
- Playwright Browser Binaries (5 installations, ~36GB)

Each example includes:
- Realistic cache key patterns
- Proper mount paths based on tool conventions
- Complete workflow snippets ready to use

All examples anonymized and tested in production environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds multiple production use case sections with ready-to-use workflows, updates Node/Bazel examples, and documents stickydisk-delete usage.
> 
> - **README**:
>   - **New use cases** with full workflow snippets:
>     - Go build and module cache
>     - Turborepo cache
>     - Python (Poetry) virtual environments
>     - Nix package cache
>     - Playwright browser binaries
>   - **Updates to existing examples**:
>     - Standardize runners to `blacksmith-*-ubuntu-2204`
>     - Switch Node setup to `actions/setup-node@v4` and bump `node-version` to `20.x`
>     - Clarify NPM caching covers both `npm` cache and `node_modules`
>   - **New section**: `useblacksmith/stickydisk-delete` usage with delete-by-key, Docker cache deletion, and a cleanup workflow example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dad6f6c81161a550107ef7c9be908395a061c5c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->