### PR TITLE
chore: promote stickydisk action from Alpha to Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 A GitHub Action that helps persist state written to disk across jobs. This action can serve as a superior alternative to the [Actions cache](https://github.com/useblacksmith/cache), especially when the cache artifacts are extremely large. Each sticky disk is hot-loaded into the runner and mounted at the specified path.
 The sticky disk is formatted as an ext4 filesystem.
 
-> [!CAUTION]
-> Alpha: This GitHub Action is currently in Alpha. There may be bugs, and the inputs/outputs and overall behavior may change without notice.
+> [!NOTE]
+> Beta: This GitHub Action is currently in Beta. The API is stable but some edge cases may still be discovered.
 
 # Architecture
 


### PR DESCRIPTION
The action is stable and ready for broader adoption.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README to indicate Beta status, replacing the Alpha caution with a Beta note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03bbd9290b59508f9a1138da6a0c0fe4f5503546. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->