### PR TITLE
fix: clear timeout in case of expose error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36400,10 +36400,15 @@ async function maybeFormatBlockDevice(device) {
 }
 async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller) {
     const timeoutId = setTimeout(() => controller.abort(), stickyDiskTimeoutMs);
-    const stickyDiskResponse = await getStickyDisk(stickyDiskKey, { signal });
+    let stickyDiskResponse;
+    try {
+        stickyDiskResponse = await getStickyDisk(stickyDiskKey, { signal });
+    }
+    finally {
+        clearTimeout(timeoutId);
+    }
     const device = stickyDiskResponse.device;
     const exposeId = stickyDiskResponse.expose_id;
-    clearTimeout(timeoutId);
     await maybeFormatBlockDevice(device);
     // Create mount point with sudo (supports system directories like /nix, /mnt, etc.)
     // Then change ownership to runner user so it's accessible
@@ -36443,7 +36448,6 @@ async function run() {
     }
     catch (error) {
         if (error instanceof Error) {
-            core.warning(`Error getting sticky disk: ${error}`);
             stickyDiskError = error;
             (0,core.saveState)("STICKYDISK_ERROR", "true");
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,10 +117,14 @@ async function mountStickyDisk(
   controller: AbortController,
 ): Promise<{ device: string; exposeId: string }> {
   const timeoutId = setTimeout(() => controller.abort(), stickyDiskTimeoutMs);
-  const stickyDiskResponse = await getStickyDisk(stickyDiskKey, { signal });
+  let stickyDiskResponse: { expose_id: string; device: string };
+  try {
+    stickyDiskResponse = await getStickyDisk(stickyDiskKey, { signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
   const device = stickyDiskResponse.device;
   const exposeId = stickyDiskResponse.expose_id;
-  clearTimeout(timeoutId);
   await maybeFormatBlockDevice(device);
   // Create mount point with sudo (supports system directories like /nix, /mnt, etc.)
   // Then change ownership to runner user so it's accessible
@@ -175,7 +179,6 @@ async function run(): Promise<void> {
     }
   } catch (error) {
     if (error instanceof Error) {
-      core.warning(`Error getting sticky disk: ${error}`);
       stickyDiskError = error;
       saveState("STICKYDISK_ERROR", "true");
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small control-flow change to ensure the abort timeout is cleared even when `getStickyDisk` throws; low risk but affects mount/expose timing behavior.
> 
> **Overview**
> Ensures the sticky-disk expose timeout is **always cleared** by wrapping the `getStickyDisk` call in `mountStickyDisk` with a `try/finally`, preventing stray abort timers when the expose request fails.
> 
> Cleans up logging to avoid duplicate warnings by removing the inner `Error getting sticky disk` warning and emitting it once after the outer error handler, and updates the compiled `dist/index.js` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c20229b74ca86093e3d08db07e36caecf1d9e110. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->