### PR TITLE
Update action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,6 @@ inputs:
     description: "The path at which to mount the sticky disk"
     required: true
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"
   post: "dist/post/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@bufbuild/protoc-gen-es": "^1.4.2",
         "@types/axios": "^0.14.4",
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.17.9",
+        "@types/node": "^24.0.0",
         "@types/node-fetch": "^2.6.11",
         "@vercel/ncc": "^0.38.1",
         "eslint": "^9.15.0",
@@ -1592,12 +1592,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -5290,9 +5291,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@bufbuild/protoc-gen-es": "^1.4.2",
     "@types/axios": "^0.14.4",
     "@types/jest": "^29.5.12",
-    "@types/node": "^20.17.9",
+    "@types/node": "^24.0.0",
     "@types/node-fetch": "^2.6.11",
     "@vercel/ncc": "^0.38.1",
     "eslint": "^9.15.0",


### PR DESCRIPTION
GitHub is [deprecating Node 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This PR migrates the stickydisk action runtime from `node20` to `node24` so it continues to work after the deprecation takes effect. The `@types/node` devDependency is also bumped from `^20` to `^24` to match the new runtime.

No source code changes are needed — the action uses stable Node APIs (`child_process`, `fs`, `util`) that are unchanged across versions. The `stickydisk-delete` action has already been running on `node24` without issues, which gives us confidence this is a safe change.

**Note:** The `package-lock.json` and `dist/` rebuild will need to happen in CI since the Buf registry packages require authentication. CI should regenerate the lock file and verify dist/ is up to date. If the build step fails because the lock file is out of sync, a follow-up commit updating `package-lock.json` after `npm install` in CI will resolve it.

### Other Blacksmith actions still on node20

These 4 non-archived repos still declare `node20` and will need the same migration:

| Repository | Notes |
|---|---|
| `useblacksmith/setup-bazel` | main + post entry points |
| `useblacksmith/setup-docker-builder` | main + post entry points |
| `useblacksmith/cache-delete` | main only |
| `useblacksmith/build-push-action` | main + post entry points |

---
[View Codesmith session](https://staging.blacksmith.sh/useblacksmith/sessions/019d2a29-3e97-7079-bf70-9f20156c274e)