### PR TITLE
fix: resolve tilde in path to prevent silent commit skip

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36427,7 +36427,8 @@ async function run() {
     let exposeId;
     let device = "";
     const stickyDiskKey = (0,core.getInput)("key");
-    const stickyDiskPath = (0,core.getInput)("path");
+    const rawPath = (0,core.getInput)("path");
+    const stickyDiskPath = (rawPath === "~" || rawPath.startsWith("~/")) ? (process.env.HOME ?? "/home/runner") + rawPath.slice(1) : rawPath;
     // Save these values to GitHub Actions state
     (0,core.saveState)("STICKYDISK_PATH", stickyDiskPath);
     (0,core.saveState)("STICKYDISK_KEY", stickyDiskKey);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import * as core from "@actions/core";
 import { promisify } from "util";
 import { exec } from "child_process";
 import { createStickyDiskClient } from "./utils";
+import { resolveTilde } from "./path";
 
 const execAsync = promisify(exec);
 
@@ -149,7 +150,7 @@ async function run(): Promise<void> {
   let exposeId: string | undefined;
   let device = "";
   const stickyDiskKey = getInput("key");
-  const stickyDiskPath = getInput("path");
+  const stickyDiskPath = resolveTilde(getInput("path"));
 
   // Save these values to GitHub Actions state
   saveState("STICKYDISK_PATH", stickyDiskPath);

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,0 +1,11 @@
+/**
+ * Resolve a leading `~` or `~/` to `$HOME`. Shell commands expand tilde
+ * automatically, but Node.js APIs and `mount | grep` do not, so state
+ * must store the resolved path for the post-run to match the mount table.
+ */
+export function resolveTilde(p: string): string {
+  if (p === "~" || p.startsWith("~/")) {
+    return (process.env.HOME ?? "/home/runner") + p.slice(1);
+  }
+  return p;
+}


### PR DESCRIPTION
## Problem

When the `path` input starts with `~` (e.g. `~/.local/share/mise`), the tilde is stored literally in GitHub Actions state via `saveState`. The post-run step then runs:

```js
mount | grep "~/.local/share/mise"
```

But the actual mount point is `/home/runner/.local/share/mise` (shell-expanded). The grep never matches, so the post-run silently returns early — **skipping unmount and commit**.

This means any stickydisk with `~` in the path never persists data across runs. The action appears to work (mount succeeds, no errors) but the cache is always empty on the next run.

## Fix

Resolve `~` to `$HOME` in `main.ts` before saving to state, so the post-run works with the expanded path.

Adds a shared `resolveTilde()` helper in `src/path.ts`.

## Testing

Verified in production CI 
- Before fix: stickydisk post-run shows no unmount/commit output, disk always empty
- After fix: post-run correctly unmounts, flushes, and commits

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->