### PR TITLE
feat: add `commit` input for restore-only mounts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   path:
     description: "The path at which to mount the sticky disk"
     required: true
+  commit:
+    description: "Whether to commit the disk on teardown. Set to 'false' for restore-only mounts where another job writes the cache."
+    required: false
+    default: "true"
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -36431,6 +36431,7 @@ async function run() {
     // Save these values to GitHub Actions state
     (0,core.saveState)("STICKYDISK_PATH", stickyDiskPath);
     (0,core.saveState)("STICKYDISK_KEY", stickyDiskKey);
+    (0,core.saveState)("STICKYDISK_COMMIT", (0,core.getInput)("commit"));
     core.info(`Mounting sticky disk at ${stickyDiskPath} with key ${stickyDiskKey}`);
     try {
         const controller = new AbortController();

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -36601,8 +36601,14 @@ async function run() {
     const stickyDiskPath = (0,core.getState)("STICKYDISK_PATH");
     const exposeId = (0,core.getState)("STICKYDISK_EXPOSE_ID");
     const stickyDiskKey = (0,core.getState)("STICKYDISK_KEY");
+    const shouldCommit = (0,core.getState)("STICKYDISK_COMMIT") !== "false";
     if (!stickyDiskPath) {
         core.debug("No STICKYDISK_PATH in state, skipping unmount");
+        return;
+    }
+    if (!shouldCommit) {
+        core.info("Commit disabled (commit: false), cleaning up without committing");
+        await cleanupStickyDiskWithoutCommit(exposeId, stickyDiskKey);
         return;
     }
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,6 +154,7 @@ async function run(): Promise<void> {
   // Save these values to GitHub Actions state
   saveState("STICKYDISK_PATH", stickyDiskPath);
   saveState("STICKYDISK_KEY", stickyDiskKey);
+  saveState("STICKYDISK_COMMIT", getInput("commit"));
 
   core.info(
     `Mounting sticky disk at ${stickyDiskPath} with key ${stickyDiskKey}`,

--- a/src/post.ts
+++ b/src/post.ts
@@ -189,9 +189,16 @@ async function run(): Promise<void> {
   const stickyDiskPath = getState("STICKYDISK_PATH");
   const exposeId = getState("STICKYDISK_EXPOSE_ID");
   const stickyDiskKey = getState("STICKYDISK_KEY");
+  const shouldCommit = getState("STICKYDISK_COMMIT") !== "false";
 
   if (!stickyDiskPath) {
     core.debug("No STICKYDISK_PATH in state, skipping unmount");
+    return;
+  }
+
+  if (!shouldCommit) {
+    core.info("Commit disabled (commit: false), cleaning up without committing");
+    await cleanupStickyDiskWithoutCommit(exposeId, stickyDiskKey);
     return;
   }
 


### PR DESCRIPTION
## Use case

CI workflows often have one job that populates a cache and many jobs that only consume it. Currently stickydisk always commits on teardown, which means every consumer job writes back an identical snapshot — wasting time and I/O.

## Change

Adds a `commit` input (default `"true"`). When set to `"false"`, the post-run step calls `cleanupStickyDiskWithoutCommit` instead of the full unmount/flush/commit cycle.

```yaml
# Writer job — populates the cache
- uses: useblacksmith/stickydisk@v1
  with:
    key: my-tools
    path: ~/tools-cache

# Reader jobs — restore only, no commit
- uses: useblacksmith/stickydisk@v1
  with:
    key: my-tools
    path: ~/tools-cache
    commit: "false"
```

## Backward compatible

Default is `"true"`, so existing workflows are unaffected.

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews (Staging)
<!-- /codesmith:footer:staging -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->