### PR TITLE
feat: expose mount and commit as separate sub-actions

### DIFF
--- a/commit/action.yml
+++ b/commit/action.yml
@@ -1,0 +1,19 @@
+name: "Blacksmith Sticky Disk — Commit"
+author: Aditya Maru
+description: "Unmount and commit a Blacksmith sticky disk. Run as a regular step after stickydisk/mount."
+branding:
+  icon: folder-plus
+  color: black
+inputs:
+  expose-id:
+    description: "The expose ID from the mount step"
+    required: true
+  key:
+    description: "The sticky disk key (must match the mount step)"
+    required: true
+  path:
+    description: "The mount path (must match the mount step, tilde OK)"
+    required: true
+runs:
+  using: "node24"
+  main: "../dist/commit/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -36437,6 +36437,9 @@ async function run() {
         try {
             ({ device, exposeId } = await mountStickyDisk(stickyDiskKey, stickyDiskPath, controller.signal, controller));
             (0,core.saveState)("STICKYDISK_EXPOSE_ID", exposeId);
+            core.setOutput("expose-id", exposeId);
+            core.setOutput("key", stickyDiskKey);
+            core.setOutput("path", stickyDiskPath);
             core.debug(`Sticky disk mounted to ${device}, expose ID: ${exposeId}`);
         }
         catch (error) {

--- a/mount/action.yml
+++ b/mount/action.yml
@@ -1,6 +1,6 @@
-name: "Blacksmith Sticky Disk"
+name: "Blacksmith Sticky Disk — Mount"
 author: Aditya Maru
-description: "Creates a sticky disk on Blacksmith"
+description: "Mount a Blacksmith sticky disk without auto-committing on teardown. Use stickydisk/commit to commit explicitly."
 branding:
   icon: folder-plus
   color: black
@@ -15,10 +15,9 @@ outputs:
   expose-id:
     description: "The expose ID for the mounted disk (pass to stickydisk/commit)"
   key:
-    description: "The sticky disk key (pass-through)"
+    description: "The sticky disk key (pass-through for convenience)"
   path:
-    description: "The mount path (pass-through)"
+    description: "The mount path (pass-through for convenience)"
 runs:
   using: "node24"
-  main: "dist/index.js"
-  post: "dist/post/index.js"
+  main: "../dist/index.js"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "ncc build src/main.ts -o dist && ncc build src/post.ts -o dist/post",
+    "build": "ncc build src/main.ts -o dist && ncc build src/post.ts -o dist/post && ncc build src/commit-main.ts -o dist/commit",
     "format": "prettier --write --cache . !dist",
     "lint": "eslint",
     "test": "jest"

--- a/src/commit-main.ts
+++ b/src/commit-main.ts
@@ -1,0 +1,158 @@
+/**
+ * Standalone commit entry point for `stickydisk/commit`.
+ *
+ * Reads expose-id, key, and path from action inputs (not state),
+ * then runs the same unmount → flush → commit logic as post.ts.
+ */
+import * as core from "@actions/core";
+import { promisify } from "util";
+import { exec } from "child_process";
+import { createStickyDiskClient } from "./utils";
+
+const execAsync = promisify(exec);
+
+async function commitStickydisk(
+  exposeId: string,
+  stickyDiskKey: string,
+  fsDiskUsageBytes: number | null,
+): Promise<void> {
+  core.info(
+    `Committing sticky disk ${stickyDiskKey} with expose ID ${exposeId}`,
+  );
+
+  try {
+    const client = await createStickyDiskClient();
+
+    const commitRequest: Record<string, unknown> = {
+      exposeId,
+      stickyDiskKey,
+      vmId: process.env.BLACKSMITH_VM_ID || "",
+      shouldCommit: true,
+      repoName: process.env.GITHUB_REPO_NAME || "",
+      stickyDiskToken: process.env.BLACKSMITH_STICKYDISK_TOKEN || "",
+    };
+
+    if (fsDiskUsageBytes !== null && fsDiskUsageBytes > 0) {
+      commitRequest.fsDiskUsageBytes = BigInt(fsDiskUsageBytes);
+    }
+
+    await client.commitStickyDisk(commitRequest, { timeoutMs: 30000 });
+    core.info(
+      `Successfully committed sticky disk ${stickyDiskKey} with expose ID ${exposeId}`,
+    );
+  } catch (error) {
+    core.warning(
+      `Error committing sticky disk: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function getDeviceFromMount(mountPoint: string): Promise<string | null> {
+  try {
+    const { stdout } = await execAsync(`findmnt -n -o SOURCE "${mountPoint}"`);
+    const device = stdout.trim();
+    if (device) return device;
+  } catch {
+    /* fall through */
+  }
+  try {
+    const { stdout } = await execAsync(`mount | grep " ${mountPoint} "`);
+    const match = stdout.match(/^(\/dev\/\S+)/);
+    if (match) return match[1];
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+const FLUSH_TIMEOUT_SECS = 10;
+
+async function flushBlockDevice(devicePath: string): Promise<void> {
+  const deviceName = devicePath.replace("/dev/", "");
+  if (!deviceName) return;
+
+  const startTime = Date.now();
+  try {
+    await execAsync(
+      `timeout ${FLUSH_TIMEOUT_SECS} sudo blockdev --flushbufs ${devicePath}`,
+    );
+    core.info(`guest flush duration: ${Date.now() - startTime}ms, device: ${devicePath}`);
+  } catch {
+    core.info(`guest flush failed for ${devicePath} after ${Date.now() - startTime}ms`);
+  }
+}
+
+/** Resolve leading `~` to $HOME since mount paths are always expanded. */
+function resolveTilde(p: string): string {
+  if (p === "~" || p.startsWith("~/")) {
+    return (process.env.HOME ?? "/home/runner") + p.slice(1);
+  }
+  return p;
+}
+
+async function run(): Promise<void> {
+  const stickyDiskPath = resolveTilde(core.getInput("path", { required: true }));
+  const exposeId = core.getInput("expose-id", { required: true });
+  const stickyDiskKey = core.getInput("key", { required: true });
+
+  core.info(`Committing stickydisk: path=${stickyDiskPath} key=${stickyDiskKey} expose-id=${exposeId}`);
+
+  try {
+    // Verify mount
+    const { stdout: mountOutput } = await execAsync(
+      `mount | grep "${stickyDiskPath}"`,
+    );
+    if (!mountOutput) {
+      core.warning(`${stickyDiskPath} is not mounted, skipping commit`);
+      return;
+    }
+
+    const devicePath = await getDeviceFromMount(stickyDiskPath);
+
+    // Sync and measure usage
+    await execAsync("sync");
+    let fsDiskUsageBytes: number | null = null;
+    try {
+      const { stdout } = await execAsync(
+        `df -B1 --output=used "${stickyDiskPath}" | tail -n1`,
+      );
+      const parsed = parseInt(stdout.trim(), 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        fsDiskUsageBytes = parsed;
+        core.info(`Filesystem usage: ${fsDiskUsageBytes} bytes`);
+      }
+    } catch {
+      /* non-fatal */
+    }
+
+    // Drop caches for clean unmount
+    await execAsync("sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'");
+
+    // Unmount with retries
+    for (let attempt = 1; attempt <= 10; attempt++) {
+      try {
+        await execAsync(`sudo umount "${stickyDiskPath}"`);
+        core.info(`Successfully unmounted ${stickyDiskPath}`);
+        break;
+      } catch (error) {
+        if (attempt === 10) throw error;
+        core.warning(`Unmount failed, retrying (${attempt}/10)...`);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      }
+    }
+
+    // Flush block device
+    if (devicePath) {
+      await flushBlockDevice(devicePath);
+    }
+
+    // Commit
+    await commitStickydisk(exposeId, stickyDiskKey, fsDiskUsageBytes);
+  } catch (error) {
+    core.warning(
+      `Failed to commit sticky disk at ${stickyDiskPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -170,6 +170,9 @@ async function run(): Promise<void> {
         controller,
       ));
       saveState("STICKYDISK_EXPOSE_ID", exposeId);
+      core.setOutput("expose-id", exposeId);
+      core.setOutput("key", stickyDiskKey);
+      core.setOutput("path", stickyDiskPath);
       core.debug(`Sticky disk mounted to ${device}, expose ID: ${exposeId}`);
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") {


### PR DESCRIPTION
Closes #26
Related: #52

## Problem

The current action always mounts in `main` and commits in `post`. There's no way to:
1. Mount a stickydisk in **restore-only** mode (skip commit entirely)
2. **Conditionally commit** based on runtime logic (e.g., skip commit when cache was already warm)
3. Control **when** the commit happens relative to other steps

#52 proposes a `commit` input which covers case 1, but cases 2 and 3 need the mount and commit to be separate, independently-callable actions.

## Solution

Add two sub-actions alongside the existing root action:

### `stickydisk/mount`
- Mounts the disk, outputs `expose-id`, `key`, `path`
- **No `post` hook** — does not auto-commit on teardown
- Reader jobs use this alone

### `stickydisk/commit`
- Takes `expose-id`, `key`, `path` as inputs
- Runs the same unmount → flush → commit logic as `post.ts`
- Called as a regular step — callers control `if:` conditions

### Root action (unchanged)
- Still works as before: mount + auto-commit
- Now also outputs `expose-id`, `key`, `path` for interop

## Usage

```yaml
# Writer job — mount, install, conditionally commit
- uses: useblacksmith/stickydisk/mount@v1
  id: cache
  with:
    key: my-tools
    path: ~/tools

- run: expensive-install
  id: install

- uses: useblacksmith/stickydisk/commit@v1
  if: steps.install.outputs.cache-miss == 'true'
  with:
    expose-id: ${{ steps.cache.outputs.expose-id }}
    key: my-tools
    path: ~/tools

# Reader jobs — restore only
- uses: useblacksmith/stickydisk/mount@v1
  with:
    key: my-tools
    path: ~/tools
```

## Build note

`dist/commit/index.js` needs to be generated by running `npm run build` after this merge. The build script is updated to include the new entry point. I couldn't run `npm install` locally because the `@buf/blacksmith_vm-agent.*` packages on buf.build returned 401.

## Backward compatible

The root action is unchanged. Existing workflows are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews (Staging)
<!-- /codesmith:footer:staging -->