### PR TITLE
fix: normalize sticky disk mount paths

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27416,6 +27416,8 @@ var core = __nccwpck_require__(7484);
 var external_util_ = __nccwpck_require__(9023);
 // EXTERNAL MODULE: external "child_process"
 var external_child_process_ = __nccwpck_require__(5317);
+// EXTERNAL MODULE: external "path"
+var external_path_ = __nccwpck_require__(6928);
 ;// CONCATENATED MODULE: ./node_modules/@bufbuild/protobuf/dist/esm/service-type.js
 // Copyright 2021-2024 Buf Technologies, Inc.
 //
@@ -36305,7 +36307,42 @@ function createStickyDiskClient() {
     return createClient(StickyDiskService, transport);
 }
 
+// EXTERNAL MODULE: external "os"
+var external_os_ = __nccwpck_require__(857);
+;// CONCATENATED MODULE: ./src/path.ts
+
+
+function shellQuote(value) {
+    return `'${value.replace(/'/g, "'\\''")}'`;
+}
+function normalizeMountPath(inputPath, options) {
+    var _a, _b;
+    const home = (_a = options === null || options === void 0 ? void 0 : options.home) !== null && _a !== void 0 ? _a : (0,external_os_.homedir)();
+    const cwd = (_b = options === null || options === void 0 ? void 0 : options.cwd) !== null && _b !== void 0 ? _b : process.cwd();
+    if (inputPath === "~") {
+        return home;
+    }
+    if (inputPath.startsWith("~/")) {
+        return external_path_.join(home, inputPath.slice(2));
+    }
+    if (external_path_.isAbsolute(inputPath)) {
+        return external_path_.normalize(inputPath);
+    }
+    return external_path_.resolve(cwd, inputPath);
+}
+function getWorkspaceLocalParentToChown(mountPath, cwd = process.cwd()) {
+    const workspacePath = external_path_.resolve(cwd);
+    const parentPath = external_path_.dirname(external_path_.resolve(mountPath));
+    if (parentPath !== workspacePath &&
+        parentPath.startsWith(`${workspacePath}${external_path_.sep}`)) {
+        return parentPath;
+    }
+    return null;
+}
+
 ;// CONCATENATED MODULE: ./src/main.ts
+
+
 
 
 
@@ -36410,15 +36447,27 @@ async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller
     const device = stickyDiskResponse.device;
     const exposeId = stickyDiskResponse.expose_id;
     await maybeFormatBlockDevice(device);
+    const parentPath = external_path_.dirname(stickyDiskPath);
+    try {
+        await execAsync(`mkdir -p ${shellQuote(parentPath)}`);
+    }
+    catch (error) {
+        core.debug(`Could not create mount parent ${parentPath} as current user: ${error instanceof Error ? error.message : String(error)}`);
+    }
     // Create mount point with sudo (supports system directories like /nix, /mnt, etc.)
     // Then change ownership to runner user so it's accessible
-    await execAsync(`sudo mkdir -p ${stickyDiskPath}`);
-    await execAsync(`sudo chown $(id -u):$(id -g) ${stickyDiskPath}`);
+    await execAsync(`sudo mkdir -p ${shellQuote(stickyDiskPath)}`);
+    await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);
+    const workspaceParentPath = getWorkspaceLocalParentToChown(stickyDiskPath);
+    if (workspaceParentPath) {
+        // Nested workspace mounts such as .nx/cache need a writable parent so tools can recreate them.
+        await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(workspaceParentPath)}`);
+    }
     // Mount the device with default options
-    await execAsync(`sudo mount ${device} ${stickyDiskPath}`);
+    await execAsync(`sudo mount ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`);
     // After mounting, ensure the mounted filesystem is owned by runner user
     // This is important because the mount operation might change ownership
-    await execAsync(`sudo chown $(id -u):$(id -g) ${stickyDiskPath}`);
+    await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);
     core.debug(`${device} has been mounted to ${stickyDiskPath} with expose ID ${exposeId}`);
     return { device, exposeId };
 }
@@ -36427,7 +36476,7 @@ async function run() {
     let exposeId;
     let device = "";
     const stickyDiskKey = (0,core.getInput)("key");
-    const stickyDiskPath = (0,core.getInput)("path");
+    const stickyDiskPath = normalizeMountPath((0,core.getInput)("path"));
     // Save these values to GitHub Actions state
     (0,core.saveState)("STICKYDISK_PATH", stickyDiskPath);
     (0,core.saveState)("STICKYDISK_KEY", stickyDiskKey);

--- a/src/__tests__/path.test.ts
+++ b/src/__tests__/path.test.ts
@@ -1,0 +1,35 @@
+import {
+  getWorkspaceLocalParentToChown,
+  normalizeMountPath,
+  shellQuote,
+} from "../path";
+
+describe("path helpers", () => {
+  it("normalizes tilde and relative mount paths before saving state", () => {
+    const options = { cwd: "/home/runner/_work/repo/repo", home: "/home/runner" };
+
+    expect(normalizeMountPath("~", options)).toBe("/home/runner");
+    expect(normalizeMountPath("~/.npm", options)).toBe("/home/runner/.npm");
+    expect(normalizeMountPath(".nx/cache", options)).toBe(
+      "/home/runner/_work/repo/repo/.nx/cache",
+    );
+  });
+
+  it("only returns workspace-local nested parents for ownership repair", () => {
+    const cwd = "/home/runner/_work/repo/repo";
+
+    expect(
+      getWorkspaceLocalParentToChown(
+        "/home/runner/_work/repo/repo/.nx/cache",
+        cwd,
+      ),
+    ).toBe("/home/runner/_work/repo/repo/.nx");
+
+    expect(getWorkspaceLocalParentToChown("/home/runner/.npm", cwd)).toBeNull();
+    expect(getWorkspaceLocalParentToChown(`${cwd}/cache`, cwd)).toBeNull();
+  });
+
+  it("quotes shell paths containing apostrophes", () => {
+    expect(shellQuote("/tmp/a'b")).toBe("'/tmp/a'\\''b'");
+  });
+});

--- a/src/__tests__/path.test.ts
+++ b/src/__tests__/path.test.ts
@@ -6,7 +6,10 @@ import {
 
 describe("path helpers", () => {
   it("normalizes tilde and relative mount paths before saving state", () => {
-    const options = { cwd: "/home/runner/_work/repo/repo", home: "/home/runner" };
+    const options = {
+      cwd: "/home/runner/_work/repo/repo",
+      home: "/home/runner",
+    };
 
     expect(normalizeMountPath("~", options)).toBe("/home/runner");
     expect(normalizeMountPath("~/.npm", options)).toBe("/home/runner/.npm");

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,13 @@ import { getInput, saveState } from "@actions/core";
 import * as core from "@actions/core";
 import { promisify } from "util";
 import { exec } from "child_process";
+import * as path from "path";
 import { createStickyDiskClient } from "./utils";
+import {
+  getWorkspaceLocalParentToChown,
+  normalizeMountPath,
+  shellQuote,
+} from "./path";
 
 const execAsync = promisify(exec);
 
@@ -126,17 +132,34 @@ async function mountStickyDisk(
   const device = stickyDiskResponse.device;
   const exposeId = stickyDiskResponse.expose_id;
   await maybeFormatBlockDevice(device);
+  const parentPath = path.dirname(stickyDiskPath);
+  try {
+    await execAsync(`mkdir -p ${shellQuote(parentPath)}`);
+  } catch (error) {
+    core.debug(
+      `Could not create mount parent ${parentPath} as current user: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
   // Create mount point with sudo (supports system directories like /nix, /mnt, etc.)
   // Then change ownership to runner user so it's accessible
-  await execAsync(`sudo mkdir -p ${stickyDiskPath}`);
-  await execAsync(`sudo chown $(id -u):$(id -g) ${stickyDiskPath}`);
+  await execAsync(`sudo mkdir -p ${shellQuote(stickyDiskPath)}`);
+  await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);
+
+  const workspaceParentPath = getWorkspaceLocalParentToChown(stickyDiskPath);
+  if (workspaceParentPath) {
+    // Nested workspace mounts such as .nx/cache need a writable parent so tools can recreate them.
+    await execAsync(
+      `sudo chown $(id -u):$(id -g) ${shellQuote(workspaceParentPath)}`,
+    );
+  }
 
   // Mount the device with default options
-  await execAsync(`sudo mount ${device} ${stickyDiskPath}`);
+  await execAsync(`sudo mount ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`);
 
   // After mounting, ensure the mounted filesystem is owned by runner user
   // This is important because the mount operation might change ownership
-  await execAsync(`sudo chown $(id -u):$(id -g) ${stickyDiskPath}`);
+  await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);
 
   core.debug(
     `${device} has been mounted to ${stickyDiskPath} with expose ID ${exposeId}`,
@@ -149,7 +172,7 @@ async function run(): Promise<void> {
   let exposeId: string | undefined;
   let device = "";
   const stickyDiskKey = getInput("key");
-  const stickyDiskPath = getInput("path");
+  const stickyDiskPath = normalizeMountPath(getInput("path"));
 
   // Save these values to GitHub Actions state
   saveState("STICKYDISK_PATH", stickyDiskPath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,7 +155,9 @@ async function mountStickyDisk(
   }
 
   // Mount the device with default options
-  await execAsync(`sudo mount ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`);
+  await execAsync(
+    `sudo mount ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`,
+  );
 
   // After mounting, ensure the mounted filesystem is owned by runner user
   // This is important because the mount operation might change ownership

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,0 +1,45 @@
+import { homedir } from "os";
+import * as path from "path";
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function normalizeMountPath(
+  inputPath: string,
+  options?: { cwd?: string; home?: string },
+): string {
+  const home = options?.home ?? homedir();
+  const cwd = options?.cwd ?? process.cwd();
+
+  if (inputPath === "~") {
+    return home;
+  }
+
+  if (inputPath.startsWith("~/")) {
+    return path.join(home, inputPath.slice(2));
+  }
+
+  if (path.isAbsolute(inputPath)) {
+    return path.normalize(inputPath);
+  }
+
+  return path.resolve(cwd, inputPath);
+}
+
+export function getWorkspaceLocalParentToChown(
+  mountPath: string,
+  cwd = process.cwd(),
+): string | null {
+  const workspacePath = path.resolve(cwd);
+  const parentPath = path.dirname(path.resolve(mountPath));
+
+  if (
+    parentPath !== workspacePath &&
+    parentPath.startsWith(`${workspacePath}${path.sep}`)
+  ) {
+    return parentPath;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Normalize sticky disk paths before saving action state so `~` mounts are unmounted and committed correctly.
- Keep workspace-local nested mount parents writable, fixing tools like Nx that recreate `.nx/cache`.
- Add focused tests for path normalization and workspace parent ownership decisions.

## Test plan
- `npm run lint`
- `npm test`
- `npm run build`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews (Staging)
<!-- /codesmith:footer:staging -->