### PR TITLE
main: keep mount parent dirs runner-owned in fallback path

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36435,6 +36435,26 @@ async function maybeFormatBlockDevice(device) {
         throw error;
     }
 }
+// Creates the mount point directory, keeping it (and any workspace-local
+// parent) owned by the runner user. Parents are created without sudo first so
+// that intermediate directories under $HOME (e.g. ~/.cache) stay writable by
+// the runner; sudo is only needed for system directories like /nix or /mnt.
+async function createMountPoint(stickyDiskPath) {
+    const parentPath = external_path_.dirname(stickyDiskPath);
+    try {
+        await execAsync(`mkdir -p ${shellQuote(parentPath)}`);
+    }
+    catch (error) {
+        core.debug(`Could not create mount parent ${parentPath} as current user: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    await execAsync(`sudo mkdir -p ${shellQuote(stickyDiskPath)}`);
+    await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);
+    const workspaceParentPath = getWorkspaceLocalParentToChown(stickyDiskPath);
+    if (workspaceParentPath) {
+        // Nested workspace mounts such as .nx/cache need a writable parent so tools can recreate them.
+        await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(workspaceParentPath)}`);
+    }
+}
 async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller) {
     const timeoutId = setTimeout(() => controller.abort(), stickyDiskTimeoutMs);
     let stickyDiskResponse;
@@ -36447,22 +36467,7 @@ async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller
     const device = stickyDiskResponse.device;
     const exposeId = stickyDiskResponse.expose_id;
     const { wasFormatted } = await maybeFormatBlockDevice(device);
-    const parentPath = external_path_.dirname(stickyDiskPath);
-    try {
-        await execAsync(`mkdir -p ${shellQuote(parentPath)}`);
-    }
-    catch (error) {
-        core.debug(`Could not create mount parent ${parentPath} as current user: ${error instanceof Error ? error.message : String(error)}`);
-    }
-    // Create mount point with sudo (supports system directories like /nix, /mnt, etc.)
-    // Then change ownership to runner user so it's accessible
-    await execAsync(`sudo mkdir -p ${shellQuote(stickyDiskPath)}`);
-    await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);
-    const workspaceParentPath = getWorkspaceLocalParentToChown(stickyDiskPath);
-    if (workspaceParentPath) {
-        // Nested workspace mounts such as .nx/cache need a writable parent so tools can recreate them.
-        await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(workspaceParentPath)}`);
-    }
+    await createMountPoint(stickyDiskPath);
     // Mount the device with default options
     await execAsync(`sudo mount ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`);
     // After mounting, ensure the mounted filesystem is owned by runner user
@@ -36473,15 +36478,10 @@ async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller
 }
 async function ensureFallbackDirectory(stickyDiskPath) {
     try {
-        // Create the directory with sudo (supports system directories like /nix, /mnt, etc.)
-        // and chown it to the runner user, mirroring what a successful mount would produce.
-        // mkdir -p and a non-recursive chown leave any existing contents untouched.
-        await execAsync(`sudo mkdir -p ${shellQuote(stickyDiskPath)}`);
-        await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);
-        const workspaceParentPath = getWorkspaceLocalParentToChown(stickyDiskPath);
-        if (workspaceParentPath) {
-            await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(workspaceParentPath)}`);
-        }
+        // Create the directory owned by the runner user, mirroring what a
+        // successful mount would produce. mkdir -p and a non-recursive chown leave
+        // any existing contents untouched.
+        await createMountPoint(stickyDiskPath);
         core.info(`Sticky disk mount failed; created empty directory at ${stickyDiskPath} so subsequent steps see a cache miss instead of a missing path`);
     }
     catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,6 +118,32 @@ async function maybeFormatBlockDevice(
   }
 }
 
+// Creates the mount point directory, keeping it (and any workspace-local
+// parent) owned by the runner user. Parents are created without sudo first so
+// that intermediate directories under $HOME (e.g. ~/.cache) stay writable by
+// the runner; sudo is only needed for system directories like /nix or /mnt.
+async function createMountPoint(stickyDiskPath: string): Promise<void> {
+  const parentPath = path.dirname(stickyDiskPath);
+  try {
+    await execAsync(`mkdir -p ${shellQuote(parentPath)}`);
+  } catch (error) {
+    core.debug(
+      `Could not create mount parent ${parentPath} as current user: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  await execAsync(`sudo mkdir -p ${shellQuote(stickyDiskPath)}`);
+  await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);
+
+  const workspaceParentPath = getWorkspaceLocalParentToChown(stickyDiskPath);
+  if (workspaceParentPath) {
+    // Nested workspace mounts such as .nx/cache need a writable parent so tools can recreate them.
+    await execAsync(
+      `sudo chown $(id -u):$(id -g) ${shellQuote(workspaceParentPath)}`,
+    );
+  }
+}
+
 async function mountStickyDisk(
   stickyDiskKey: string,
   stickyDiskPath: string,
@@ -134,27 +160,8 @@ async function mountStickyDisk(
   const device = stickyDiskResponse.device;
   const exposeId = stickyDiskResponse.expose_id;
   const { wasFormatted } = await maybeFormatBlockDevice(device);
-  const parentPath = path.dirname(stickyDiskPath);
-  try {
-    await execAsync(`mkdir -p ${shellQuote(parentPath)}`);
-  } catch (error) {
-    core.debug(
-      `Could not create mount parent ${parentPath} as current user: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
 
-  // Create mount point with sudo (supports system directories like /nix, /mnt, etc.)
-  // Then change ownership to runner user so it's accessible
-  await execAsync(`sudo mkdir -p ${shellQuote(stickyDiskPath)}`);
-  await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);
-
-  const workspaceParentPath = getWorkspaceLocalParentToChown(stickyDiskPath);
-  if (workspaceParentPath) {
-    // Nested workspace mounts such as .nx/cache need a writable parent so tools can recreate them.
-    await execAsync(
-      `sudo chown $(id -u):$(id -g) ${shellQuote(workspaceParentPath)}`,
-    );
-  }
+  await createMountPoint(stickyDiskPath);
 
   // Mount the device with default options
   await execAsync(
@@ -173,20 +180,10 @@ async function mountStickyDisk(
 
 async function ensureFallbackDirectory(stickyDiskPath: string): Promise<void> {
   try {
-    // Create the directory with sudo (supports system directories like /nix, /mnt, etc.)
-    // and chown it to the runner user, mirroring what a successful mount would produce.
-    // mkdir -p and a non-recursive chown leave any existing contents untouched.
-    await execAsync(`sudo mkdir -p ${shellQuote(stickyDiskPath)}`);
-    await execAsync(
-      `sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`,
-    );
-
-    const workspaceParentPath = getWorkspaceLocalParentToChown(stickyDiskPath);
-    if (workspaceParentPath) {
-      await execAsync(
-        `sudo chown $(id -u):$(id -g) ${shellQuote(workspaceParentPath)}`,
-      );
-    }
+    // Create the directory owned by the runner user, mirroring what a
+    // successful mount would produce. mkdir -p and a non-recursive chown leave
+    // any existing contents untouched.
+    await createMountPoint(stickyDiskPath);
 
     core.info(
       `Sticky disk mount failed; created empty directory at ${stickyDiskPath} so subsequent steps see a cache miss instead of a missing path`,


### PR DESCRIPTION
## Summary
Fixes root-owned parent directories left behind when a sticky disk fails to expose, which surfaces later as EACCES errors from tools like corepack (`Error: EACCES: permission denied, mkdir '/home/runner/.cache/node/corepack/v1'`).

Root cause: on expose timeout/failure, `ensureFallbackDirectory` ran only `sudo mkdir -p <path>`, so any missing intermediate dirs (e.g. `/home/runner/.cache` for a `~/.cache/uv` mount) were created `root:root`, and only the leaf was chowned back to the runner. The successful mount path (`mountStickyDisk`) already avoided this by first running a non-sudo `mkdir -p` on the parent.

Change: extract that logic into `createMountPoint(stickyDiskPath)` (non-sudo parent `mkdir -p` → `sudo mkdir -p` leaf → chown leaf + workspace-local parent) and use it from both `mountStickyDisk` and `ensureFallbackDirectory`.

Observed in production on `blacksmith-01kwz990dntbn1dvjhk60tyzmb-4vcpu` (langchain-ai): three sticky disks (`go-cache`, `pnpm-store`, `uv-cache`) hit the 45s expose timeout, the fallback created `/home/runner/.cache` as root, and the next step's corepack invocation failed with EACCES.

Link to Devin session: https://app.devin.ai/sessions/c8e9c0baeeae4bb2b08f6327a3bf477f
Requested by: @piob-io

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://stagingbackend.blacksmith.sh/track/enable-autofix?expires=1786113058&installation_id=57496780&pr_number=61&repository=useblacksmith%2Fstickydisk&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fstickydisk%2Fpull%2F61&signature=4fe2d8c102e60a47a6c85379ac01593a5a195bc35ed61be3382fc5a19d2357d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled. (Staging)</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer:staging -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786113062&installation_id=59834506&pr_number=61&repository=useblacksmith%2Fstickydisk&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fstickydisk%2Fpull%2F61&signature=d826ddbcd3154ec0ba0bda8c565a672f38d3afbb0b46918c03f7bf1eb1a0070c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->