### PR TITLE
main: wait for non-zero device size before formatting sticky disk

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36372,6 +36372,30 @@ async function getStickyDisk(stickyDiskKey, options) {
         device: response.diskIdentifier,
     };
 }
+// The VM agent's sticky-disk response can arrive before the guest kernel has
+// processed the virtio config-change interrupt that publishes the drive's real
+// capacity (the drive is hot-attached/hydrated in place), so the device can
+// transiently report a size of zero. Wait for a non-zero size before touching
+// the device.
+async function waitForNonZeroDeviceSize(device, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+        try {
+            const { stdout } = await execAsync(`sudo blockdev --getsize64 ${device}`);
+            const size = parseInt(stdout.trim(), 10);
+            if (!isNaN(size) && size > 0) {
+                return;
+            }
+        }
+        catch {
+            // Device node may not exist yet; keep polling until the deadline.
+        }
+        if (Date.now() >= deadline) {
+            throw new Error(`Device ${device} still reports zero size after ${timeoutMs}ms`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+}
 async function maybeFormatBlockDevice(device) {
     try {
         // Check if device is formatted with ext4
@@ -36466,6 +36490,7 @@ async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller
     }
     const device = stickyDiskResponse.device;
     const exposeId = stickyDiskResponse.expose_id;
+    await waitForNonZeroDeviceSize(device, 10000);
     const { wasFormatted } = await maybeFormatBlockDevice(device);
     await createMountPoint(stickyDiskPath);
     // Mount the device with default options

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,35 @@ async function getStickyDisk(
   };
 }
 
+// The VM agent's sticky-disk response can arrive before the guest kernel has
+// processed the virtio config-change interrupt that publishes the drive's real
+// capacity (the drive is hot-attached/hydrated in place), so the device can
+// transiently report a size of zero. Wait for a non-zero size before touching
+// the device.
+async function waitForNonZeroDeviceSize(
+  device: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const { stdout } = await execAsync(`sudo blockdev --getsize64 ${device}`);
+      const size = parseInt(stdout.trim(), 10);
+      if (!isNaN(size) && size > 0) {
+        return;
+      }
+    } catch {
+      // Device node may not exist yet; keep polling until the deadline.
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Device ${device} still reports zero size after ${timeoutMs}ms`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
 async function maybeFormatBlockDevice(
   device: string,
 ): Promise<{ device: string; wasFormatted: boolean }> {
@@ -159,6 +188,7 @@ async function mountStickyDisk(
   }
   const device = stickyDiskResponse.device;
   const exposeId = stickyDiskResponse.expose_id;
+  await waitForNonZeroDeviceSize(device, 10000);
   const { wasFormatted } = await maybeFormatBlockDevice(device);
 
   await createMountPoint(stickyDiskPath);


### PR DESCRIPTION
## Summary
Port of useblacksmith/setup-docker-builder#118: the VM agent's sticky-disk response can arrive before the guest kernel has processed the virtio config-change interrupt publishing the drive's real capacity, so the device transiently reports size 0. In that window `blkid` finds no filesystem and `maybeFormatBlockDevice` **reformats an already-populated sticky disk**, wiping the cache; a fresh format/mount can also fail outright.

`mountStickyDisk` now calls `waitForNonZeroDeviceSize(device, 10000)` (poll `blockdev --getsize64` every 100 ms) before the blkid/format/mount sequence, failing with a clear error if the device never becomes ready.

Link to Devin session: https://app.devin.ai/sessions/ba61e842e479410d95116fe1dfe77b0f
Requested by: @piob-io

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786815714&installation_id=59834506&pr_number=63&repository=useblacksmith%2Fstickydisk&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fstickydisk%2Fpull%2F63&signature=63abc118f0b7e0f42a109801cc5f8ea1b2cbb559f71c7f714f7e1c0a443ef04a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://stagingbackend.blacksmith.sh/track/enable-autofix?expires=1786815718&installation_id=57496780&pr_number=63&repository=useblacksmith%2Fstickydisk&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fstickydisk%2Fpull%2F63&signature=1fa397b670106a6e6dc7450c26fa2827057c895ea3dce8aa84aef46fbb4b0f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled. (Staging)</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer:staging -->