### PR TITLE
ci: pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version-file: .nvmrc
 
       - name: Setup Buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
 
       - name: Configure Buf Registry
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
           fetch-depth: 0
@@ -49,12 +49,12 @@ jobs:
           echo "Version $VERSION is available"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version-file: .nvmrc
 
       - name: Setup buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ github.token }}
 


### PR DESCRIPTION
Resolves the Aikido action-pinning finding (group 14426944, Linear SEC-512). stickydisk is a public, customer-consumed action whose release workflow runs with `contents: write` + `BUF_TOKEN` and force-moves the `v1` floating tag customers pull, so a compromised third-party action here is a supply-chain path into every consumer. All actions in `build.yaml` and `release.yml` are now pinned to full commit SHAs with version comments that Dependabot's existing daily `github-actions` config keeps updated:

```yaml
uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
```

Pins verified against upstream refs; `bufbuild/buf-setup-action`'s `v1` branch head is the same commit as `v1.50.0`, so behavior is identical to what `@v1` resolves today.

Risk stoplight: GREEN. Config-only, no dependency or code changes; SHAs resolve to the exact commits the floating tags/refs point at today. Revert = single commit revert.