### PR TITLE
main: skip sticky disk mount gracefully on windows and macos runners

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36537,10 +36537,11 @@ async function run() {
     const stickyDiskKey = (0,core.getInput)("key");
     const stickyDiskPath = normalizeMountPath((0,core.getInput)("path"));
     const commitMode = (0,core.getInput)("commit") || "true";
-    if (process.platform === "win32") {
-        core.warning(`Sticky disks are not supported on Windows runners; skipping mount at ${stickyDiskPath}. ` +
+    if (process.platform === "win32" || process.platform === "darwin") {
+        const platformName = process.platform === "win32" ? "Windows" : "macOS";
+        core.warning(`Sticky disks are not supported on ${platformName} runners; skipping mount at ${stickyDiskPath}. ` +
             "Subsequent steps will see an empty directory (a cache miss). " +
-            "Remove this step from Windows jobs to silence this warning.");
+            `Remove this step from ${platformName} jobs to silence this warning.`);
         try {
             await external_fs_.promises.mkdir(stickyDiskPath, { recursive: true });
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -27416,6 +27416,8 @@ var core = __nccwpck_require__(7484);
 var external_util_ = __nccwpck_require__(9023);
 // EXTERNAL MODULE: external "child_process"
 var external_child_process_ = __nccwpck_require__(5317);
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __nccwpck_require__(9896);
 // EXTERNAL MODULE: external "path"
 var external_path_ = __nccwpck_require__(6928);
 ;// CONCATENATED MODULE: ./node_modules/@bufbuild/protobuf/dist/esm/service-type.js
@@ -36348,6 +36350,7 @@ function getWorkspaceLocalParentToChown(mountPath, cwd = process.cwd()) {
 
 
 
+
 const execAsync = (0,external_util_.promisify)(external_child_process_.exec);
 // stickyDiskTimeoutMs states the max amount of time this action will wait for the VM agent to
 // expose the sticky disk from the storage agent, map it onto the host and then patch the drive
@@ -36534,6 +36537,18 @@ async function run() {
     const stickyDiskKey = (0,core.getInput)("key");
     const stickyDiskPath = normalizeMountPath((0,core.getInput)("path"));
     const commitMode = (0,core.getInput)("commit") || "true";
+    if (process.platform === "win32") {
+        core.warning(`Sticky disks are not supported on Windows runners; skipping mount at ${stickyDiskPath}. ` +
+            "Subsequent steps will see an empty directory (a cache miss). " +
+            "Remove this step from Windows jobs to silence this warning.");
+        try {
+            await external_fs_.promises.mkdir(stickyDiskPath, { recursive: true });
+        }
+        catch (error) {
+            core.warning(`Failed to create fallback directory at ${stickyDiskPath}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        return;
+    }
     // Save these values to GitHub Actions state
     (0,core.saveState)("STICKYDISK_PATH", stickyDiskPath);
     (0,core.saveState)("STICKYDISK_KEY", stickyDiskKey);

--- a/src/main.ts
+++ b/src/main.ts
@@ -254,11 +254,12 @@ async function run(): Promise<void> {
   const stickyDiskPath = normalizeMountPath(getInput("path"));
   const commitMode = getInput("commit") || "true";
 
-  if (process.platform === "win32") {
+  if (process.platform === "win32" || process.platform === "darwin") {
+    const platformName = process.platform === "win32" ? "Windows" : "macOS";
     core.warning(
-      `Sticky disks are not supported on Windows runners; skipping mount at ${stickyDiskPath}. ` +
+      `Sticky disks are not supported on ${platformName} runners; skipping mount at ${stickyDiskPath}. ` +
         "Subsequent steps will see an empty directory (a cache miss). " +
-        "Remove this step from Windows jobs to silence this warning.",
+        `Remove this step from ${platformName} jobs to silence this warning.`,
     );
     try {
       await fs.promises.mkdir(stickyDiskPath, { recursive: true });

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { getInput, saveState } from "@actions/core";
 import * as core from "@actions/core";
 import { promisify } from "util";
 import { exec } from "child_process";
+import * as fs from "fs";
 import * as path from "path";
 import { createStickyDiskClient } from "./utils";
 import {
@@ -252,6 +253,22 @@ async function run(): Promise<void> {
   const stickyDiskKey = getInput("key");
   const stickyDiskPath = normalizeMountPath(getInput("path"));
   const commitMode = getInput("commit") || "true";
+
+  if (process.platform === "win32") {
+    core.warning(
+      `Sticky disks are not supported on Windows runners; skipping mount at ${stickyDiskPath}. ` +
+        "Subsequent steps will see an empty directory (a cache miss). " +
+        "Remove this step from Windows jobs to silence this warning.",
+    );
+    try {
+      await fs.promises.mkdir(stickyDiskPath, { recursive: true });
+    } catch (error) {
+      core.warning(
+        `Failed to create fallback directory at ${stickyDiskPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return;
+  }
 
   // Save these values to GitHub Actions state
   saveState("STICKYDISK_PATH", stickyDiskPath);


### PR DESCRIPTION
## Summary

Sticky disks are not supported on Windows or macOS runners. On Windows (CloudHypervisor) VMs the agent never registers sticky disk metadata, so every in-guest `GetStickyDisk` call fails after the 45s timeout and the action falls back to a plain directory anyway (~16k errors/day, mostly `Factory-AI/factory-mono`). On macOS (vz) hosts the agent does not run the sticky disk gRPC service at all, so the mount can never succeed there either.

This change detects `win32`/`darwin` at the top of `run()` and:

- emits a single actionable warning telling the user sticky disks are unsupported on that platform and to remove the step,
- creates the target directory so subsequent steps behave like a cache miss,
- returns before any state is saved, so the post step is a no-op (no commit attempt, no report-failed call).

Companion agent-side fix for Windows (fast, clean `codes.Unimplemented` instead of a 45s timeout for older action versions): FastActions/fa#4814. No agent-side change is needed for macOS since no sticky disk service runs there.

`dist/` was rebuilt with `npm run build` (same pinned toolchain as CI) and lint/tests/prettier pass.