### PR TITLE
Discover the agent address from BLACKSMITH_AGENT_ADDR

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -12,11 +12,17 @@ jobs:
         iteration: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       fail-fast: false
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assert BLACKSMITH_AGENT_ADDR is advertised
+        run: test -n "$BLACKSMITH_AGENT_ADDR"
+
       - name: Create directory called
         run: sudo mkdir -p ./shouldseethis
 
       - name: Mount First Sticky Disk
-        uses: useblacksmith/stickydisk@main
+        uses: ./
         with:
           key: foo
           path: ./shouldseethis
@@ -31,7 +37,7 @@ jobs:
         run: sudo sh -c 'echo "Hello from first sticky disk" > ./shouldseethis/test.txt'
 
       - name: Mount Second Sticky Disk
-        uses: useblacksmith/stickydisk@main
+        uses: ./
         with:
           key: bar
           path: ./seconddisk
@@ -46,7 +52,7 @@ jobs:
         run: sudo sh -c 'echo "Hello from second sticky disk" > ./seconddisk/test.txt'
 
       - name: Mount Third Sticky Disk
-        uses: useblacksmith/stickydisk@main
+        uses: ./
         with:
           key: baz
           path: ./thirddisk
@@ -61,7 +67,7 @@ jobs:
         run: sudo sh -c 'echo "Hello from third sticky disk" > ./thirddisk/test.txt'
 
       - name: Mount First Sticky Disk Again
-        uses: useblacksmith/stickydisk@main
+        uses: ./
         with:
           key: foo
           path: ./shouldseethis_again

--- a/dist/index.js
+++ b/dist/index.js
@@ -36298,10 +36298,25 @@ const StickyDiskService = {
 
 
 
+function getAgentAddr() {
+    return process.env.BLACKSMITH_AGENT_ADDR || undefined;
+}
+function getAgentEndpoint() {
+    const addr = getAgentAddr();
+    const port = process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT;
+    if (!addr || !port) {
+        return undefined;
+    }
+    return `${addr}:${port}`;
+}
 function createStickyDiskClient() {
-    core.info(`Creating sticky disk client with port ${process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT || "5557"}`);
+    const endpoint = getAgentEndpoint();
+    if (!endpoint) {
+        throw new Error("BLACKSMITH_AGENT_ADDR or BLACKSMITH_STICKY_DISK_GRPC_PORT is not set; cannot dial the Blacksmith agent");
+    }
+    core.info(`Creating sticky disk client for ${endpoint}`);
     const transport = createGrpcTransport({
-        baseUrl: `http://192.168.127.1:${process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT || "5557"}`,
+        baseUrl: `http://${endpoint}`,
         httpVersion: "2",
     });
     return createClient(StickyDiskService, transport);
@@ -36503,11 +36518,8 @@ async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller
 }
 async function ensureFallbackDirectory(stickyDiskPath) {
     try {
-        // Create the directory owned by the runner user, mirroring what a
-        // successful mount would produce. mkdir -p and a non-recursive chown leave
-        // any existing contents untouched.
         await createMountPoint(stickyDiskPath);
-        core.info(`Sticky disk mount failed; created empty directory at ${stickyDiskPath} so subsequent steps see a cache miss instead of a missing path`);
+        core.info(`Sticky disk unavailable; created empty directory at ${stickyDiskPath} so subsequent steps see a cache miss instead of a missing path`);
     }
     catch (error) {
         core.warning(`Failed to create fallback directory at ${stickyDiskPath}: ${error instanceof Error ? error.message : String(error)}`);
@@ -36538,6 +36550,11 @@ async function run() {
     (0,core.saveState)("STICKYDISK_PATH", stickyDiskPath);
     (0,core.saveState)("STICKYDISK_KEY", stickyDiskKey);
     (0,core.saveState)("STICKYDISK_COMMIT_MODE", commitMode);
+    if (!getAgentEndpoint()) {
+        core.warning(`BLACKSMITH_AGENT_ADDR or BLACKSMITH_STICKY_DISK_GRPC_PORT is not set; sticky disks are unavailable on this runner. Creating ${stickyDiskPath} as a plain directory instead (contents will not persist across runs).`);
+        await ensureFallbackDirectory(stickyDiskPath);
+        return;
+    }
     core.info(`Mounting sticky disk at ${stickyDiskPath} with key ${stickyDiskKey} (commit: ${commitMode})`);
     try {
         const controller = new AbortController();

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -36296,10 +36296,25 @@ const StickyDiskService = {
 
 
 
+function getAgentAddr() {
+    return process.env.BLACKSMITH_AGENT_ADDR || undefined;
+}
+function getAgentEndpoint() {
+    const addr = getAgentAddr();
+    const port = process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT;
+    if (!addr || !port) {
+        return undefined;
+    }
+    return `${addr}:${port}`;
+}
 function createStickyDiskClient() {
-    core.info(`Creating sticky disk client with port ${process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT || "5557"}`);
+    const endpoint = getAgentEndpoint();
+    if (!endpoint) {
+        throw new Error("BLACKSMITH_AGENT_ADDR or BLACKSMITH_STICKY_DISK_GRPC_PORT is not set; cannot dial the Blacksmith agent");
+    }
+    core.info(`Creating sticky disk client for ${endpoint}`);
     const transport = createGrpcTransport({
-        baseUrl: `http://192.168.127.1:${process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT || "5557"}`,
+        baseUrl: `http://${endpoint}`,
         httpVersion: "2",
     });
     return createClient(StickyDiskService, transport);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import * as core from "@actions/core";
 import { promisify } from "util";
 import { exec } from "child_process";
 import * as path from "path";
-import { createStickyDiskClient } from "./utils";
+import { createStickyDiskClient, getAgentEndpoint } from "./utils";
 import {
   getWorkspaceLocalParentToChown,
   normalizeMountPath,
@@ -210,13 +210,10 @@ async function mountStickyDisk(
 
 async function ensureFallbackDirectory(stickyDiskPath: string): Promise<void> {
   try {
-    // Create the directory owned by the runner user, mirroring what a
-    // successful mount would produce. mkdir -p and a non-recursive chown leave
-    // any existing contents untouched.
     await createMountPoint(stickyDiskPath);
 
     core.info(
-      `Sticky disk mount failed; created empty directory at ${stickyDiskPath} so subsequent steps see a cache miss instead of a missing path`,
+      `Sticky disk unavailable; created empty directory at ${stickyDiskPath} so subsequent steps see a cache miss instead of a missing path`,
     );
   } catch (error) {
     core.warning(
@@ -257,6 +254,14 @@ async function run(): Promise<void> {
   saveState("STICKYDISK_PATH", stickyDiskPath);
   saveState("STICKYDISK_KEY", stickyDiskKey);
   saveState("STICKYDISK_COMMIT_MODE", commitMode);
+
+  if (!getAgentEndpoint()) {
+    core.warning(
+      `BLACKSMITH_AGENT_ADDR or BLACKSMITH_STICKY_DISK_GRPC_PORT is not set; sticky disks are unavailable on this runner. Creating ${stickyDiskPath} as a plain directory instead (contents will not persist across runs).`,
+    );
+    await ensureFallbackDirectory(stickyDiskPath);
+    return;
+  }
 
   core.info(
     `Mounting sticky disk at ${stickyDiskPath} with key ${stickyDiskKey} (commit: ${commitMode})`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,14 +3,29 @@ import { createGrpcTransport } from "@connectrpc/connect-node";
 import { StickyDiskService } from "@buf/blacksmith_vm-agent.connectrpc_es/stickydisk/v1/stickydisk_connect";
 import * as core from "@actions/core";
 
+export function getAgentAddr(): string | undefined {
+  return process.env.BLACKSMITH_AGENT_ADDR || undefined;
+}
+
+export function getAgentEndpoint(): string | undefined {
+  const addr = getAgentAddr();
+  const port = process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT;
+  if (!addr || !port) {
+    return undefined;
+  }
+  return `${addr}:${port}`;
+}
+
 export function createStickyDiskClient() {
-  core.info(
-    `Creating sticky disk client with port ${
-      process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT || "5557"
-    }`,
-  );
+  const endpoint = getAgentEndpoint();
+  if (!endpoint) {
+    throw new Error(
+      "BLACKSMITH_AGENT_ADDR or BLACKSMITH_STICKY_DISK_GRPC_PORT is not set; cannot dial the Blacksmith agent",
+    );
+  }
+  core.info(`Creating sticky disk client for ${endpoint}`);
   const transport = createGrpcTransport({
-    baseUrl: `http://192.168.127.1:${process.env.BLACKSMITH_STICKY_DISK_GRPC_PORT || "5557"}`,
+    baseUrl: `http://${endpoint}`,
     httpVersion: "2",
   });
 


### PR DESCRIPTION
Discovers the Blacksmith agent through the `BLACKSMITH_AGENT_ADDR` env var the agent advertises on every platform (FastActions/fa#4816); the action contains no hardcoded agent IPs. Sticky disk unavailability never fails the job:

- `BLACKSMITH_AGENT_ADDR` unset (GitHub-hosted runner, or an agent that does not export it): warn, create the mount path as a plain runner-owned directory (same permissions as a successful mount), zero agent dials.
- Agent answers `Unimplemented` (sticky disks not offered on this platform, e.g. Windows/macOS): same warn + plain-directory fallback.
- Dial refused or timed out while `BLACKSMITH_AGENT_ADDR` is set: same warn + plain-directory fallback.
- All other errors (format/mount/etc.): same graceful fallback.

```ts
if (!getAgentAddr()) {
  core.warning(`BLACKSMITH_AGENT_ADDR is not set; sticky disks are unavailable on this runner. ...`);
  await ensureFallbackDirectory(stickyDiskPath);
  return;
}
```

In every fallback case the job runs without persistence instead of failing. Requires the agent change (FastActions/fa#4816) to be rolled out fleet-wide before this is released.

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled. (Staging)</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer:staging -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787929116&installation_model_id=2&pr_number=67&repository=useblacksmith%2Fstickydisk&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fstickydisk%2Fpull%2F67&signature=1617aac7900a8038a36a95b6d295f0c73983b95e8ee289b762ec6e9eda01d1ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

