### PR TITLE
mount sticky disks with noinit_itable to stop repeated lazy-init writes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36440,7 +36440,7 @@ async function maybeFormatBlockDevice(device) {
         const tempMount = `/tmp/stickydisk-init-${Date.now()}`;
         try {
             await execAsync(`sudo mkdir -p ${tempMount}`);
-            await execAsync(`sudo mount ${device} ${tempMount}`);
+            await execAsync(`sudo mount -o noinit_itable ${device} ${tempMount}`);
             await execAsync(`sudo rm -rf ${tempMount}/lost+found`);
             await execAsync(`sudo umount ${tempMount}`);
             await execAsync(`sudo rmdir ${tempMount}`);
@@ -36493,8 +36493,15 @@ async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller
     await waitForNonZeroDeviceSize(device, 10000);
     const { wasFormatted } = await maybeFormatBlockDevice(device);
     await createMountPoint(stickyDiskPath);
-    // Mount the device with default options
-    await execAsync(`sudo mount ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`);
+    // Mount with noinit_itable to keep the ext4lazyinit kernel thread from
+    // zeroing uninitialized inode tables in the background. Sticky disks are
+    // copy-on-write clones of a committed snapshot: if the snapshot was taken
+    // before lazy init finished, every clone would redo the same multi-GB
+    // zeroing and the writes are thrown away when the clone is discarded. The
+    // zeroing is unnecessary here anyway - mkfs enables checksummed group
+    // descriptors that track unused inodes, and unallocated blocks on the
+    // thin-provisioned device already read back as zeroes.
+    await execAsync(`sudo mount -o noinit_itable ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`);
     // After mounting, ensure the mounted filesystem is owned by runner user
     // This is important because the mount operation might change ownership
     await execAsync(`sudo chown $(id -u):$(id -g) ${shellQuote(stickyDiskPath)}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -36493,14 +36493,8 @@ async function mountStickyDisk(stickyDiskKey, stickyDiskPath, signal, controller
     await waitForNonZeroDeviceSize(device, 10000);
     const { wasFormatted } = await maybeFormatBlockDevice(device);
     await createMountPoint(stickyDiskPath);
-    // Mount with noinit_itable to keep the ext4lazyinit kernel thread from
-    // zeroing uninitialized inode tables in the background. Sticky disks are
-    // copy-on-write clones of a committed snapshot: if the snapshot was taken
-    // before lazy init finished, every clone would redo the same multi-GB
-    // zeroing and the writes are thrown away when the clone is discarded. The
-    // zeroing is unnecessary here anyway - mkfs enables checksummed group
-    // descriptors that track unused inodes, and unallocated blocks on the
-    // thin-provisioned device already read back as zeroes.
+    // noinit_itable stops the background zeroing of a non-trivial portion of
+    // the device (uninitialized inode tables), which is unnecessary here.
     await execAsync(`sudo mount -o noinit_itable ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`);
     // After mounting, ensure the mounted filesystem is owned by runner user
     // This is important because the mount operation might change ownership

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,7 +126,7 @@ async function maybeFormatBlockDevice(
     const tempMount = `/tmp/stickydisk-init-${Date.now()}`;
     try {
       await execAsync(`sudo mkdir -p ${tempMount}`);
-      await execAsync(`sudo mount ${device} ${tempMount}`);
+      await execAsync(`sudo mount -o noinit_itable ${device} ${tempMount}`);
       await execAsync(`sudo rm -rf ${tempMount}/lost+found`);
       await execAsync(`sudo umount ${tempMount}`);
       await execAsync(`sudo rmdir ${tempMount}`);
@@ -193,9 +193,16 @@ async function mountStickyDisk(
 
   await createMountPoint(stickyDiskPath);
 
-  // Mount the device with default options
+  // Mount with noinit_itable to keep the ext4lazyinit kernel thread from
+  // zeroing uninitialized inode tables in the background. Sticky disks are
+  // copy-on-write clones of a committed snapshot: if the snapshot was taken
+  // before lazy init finished, every clone would redo the same multi-GB
+  // zeroing and the writes are thrown away when the clone is discarded. The
+  // zeroing is unnecessary here anyway - mkfs enables checksummed group
+  // descriptors that track unused inodes, and unallocated blocks on the
+  // thin-provisioned device already read back as zeroes.
   await execAsync(
-    `sudo mount ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`,
+    `sudo mount -o noinit_itable ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`,
   );
 
   // After mounting, ensure the mounted filesystem is owned by runner user

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,14 +193,8 @@ async function mountStickyDisk(
 
   await createMountPoint(stickyDiskPath);
 
-  // Mount with noinit_itable to keep the ext4lazyinit kernel thread from
-  // zeroing uninitialized inode tables in the background. Sticky disks are
-  // copy-on-write clones of a committed snapshot: if the snapshot was taken
-  // before lazy init finished, every clone would redo the same multi-GB
-  // zeroing and the writes are thrown away when the clone is discarded. The
-  // zeroing is unnecessary here anyway - mkfs enables checksummed group
-  // descriptors that track unused inodes, and unallocated blocks on the
-  // thin-provisioned device already read back as zeroes.
+  // noinit_itable stops the background zeroing of a non-trivial portion of
+  // the device (uninitialized inode tables), which is unnecessary here.
   await execAsync(
     `sudo mount -o noinit_itable ${shellQuote(device)} ${shellQuote(stickyDiskPath)}`,
   );


### PR DESCRIPTION
## Summary
Sticky disks are formatted with `mkfs.ext4 -E lazy_itable_init=1`, which defers inode-table zeroing to a background kernel thread (`ext4lazyinit`) that runs after mount. Because sticky disks are copy-on-write clones of a committed snapshot, an entity whose snapshot was taken before lazy init finished replays the same zeroing on **every** clone — multi-GB of Ceph writes per job that are discarded with the clone and never converge.

Measured example: artemisai-main's `devcontainer-*` disks (read-only tar caches that commit once per key) show a byte-exact constant 8.8 GiB of dirty blocks on 91k clones over 14 days — ~55 TB/day of pure lazy-init zeroing on eu-west.

Fix: mount with `-o noinit_itable`, which disables the zeroing thread. The zeroing is unnecessary for correctness — mkfs enables checksummed group descriptors that track unused inodes, and unallocated blocks on the thin-provisioned RBD device read back as zeroes anyway. Applied to both the main mount and the temporary `lost+found`-cleanup mount. This covers existing disks (whose frozen snapshots can't be repaired any other way) as well as new ones.

Link to Devin session: https://app.devin.ai/sessions/1054a9452e8a49ccb891391e2327a612
Requested by: @piob-io

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787953101&installation_model_id=2&pr_number=68&repository=useblacksmith%2Fstickydisk&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fstickydisk%2Fpull%2F68&signature=ca73ddf44999fdc3106834c97c239b8feef9772cb6e979948cb9816ceacd672d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/useblacksmith/codesmith/stickydisk/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://stagingbackend.blacksmith.sh/track/enable-autofix?expires=1787953105&installation_model_id=8&pr_number=68&repository=useblacksmith%2Fstickydisk&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fstickydisk%2Fpull%2F68&signature=144b258c3c68e6ae29f6ee5cc33818293c1db278498d1014f77609727424d1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled. (Staging)</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer:staging -->