### PR TITLE
fix: match the runner's "Canceled" spelling so cancelled jobs skip the commit

### DIFF
--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -36328,6 +36328,9 @@ var external_path_ = __nccwpck_require__(6928);
 
 
 
+// The runner's TaskResult enum spells it "Canceled", not "Cancelled", so a cancelled step
+// was read as a clean run. Accept either spelling, and any casing.
+const FAILURE_RESULT = /^(?:failed|cancell?ed)$/i;
 /**
  * Checks GitHub Actions runner logs for failed or cancelled steps
  * @param runnerBasePath - Base path to runner directory (default: auto-detect)
@@ -36393,10 +36396,8 @@ async function checkPreviousStepFailures(runnerBasePath) {
         const logContent = await external_fs_.promises.readFile(workerLogPath, "utf-8");
         // Patterns to match failed or cancelled steps
         const failurePatterns = [
-            /"result":\s*"failed"/g,
-            /"result":\s*"cancelled"/g,
-            /Step result:\s*Failed/g,
-            /Step result:\s*Cancelled/g,
+            /"result":\s*"(?:failed|cancell?ed)"/gi,
+            /Step result:\s*(?:failed|cancell?ed)/gi,
         ];
         // Count total failures
         let failedCount = 0;
@@ -36409,7 +36410,7 @@ async function checkPreviousStepFailures(runnerBasePath) {
         // Extract detailed failure information
         const failedSteps = [];
         // Regex to extract JSON objects containing step information
-        const jsonStepPattern = /\{[^{}]*"result":\s*"(?:failed|cancelled)"[^{}]*\}/g;
+        const jsonStepPattern = /\{[^{}]*"result":\s*"(?:failed|cancell?ed)"[^{}]*\}/gi;
         const jsonMatches = logContent.match(jsonStepPattern);
         if (jsonMatches) {
             for (const match of jsonMatches) {
@@ -36421,8 +36422,7 @@ async function checkPreviousStepFailures(runnerBasePath) {
                     if (contextEnd > contextStart) {
                         const contextJson = logContent.substring(contextStart, contextEnd);
                         const stepData = JSON.parse(contextJson);
-                        if (stepData.result === "failed" ||
-                            stepData.result === "cancelled") {
+                        if (FAILURE_RESULT.test(stepData.result)) {
                             failedSteps.push({
                                 action: stepData.action,
                                 stepName: stepData.stepName || stepData.displayName,
@@ -36436,8 +36436,7 @@ async function checkPreviousStepFailures(runnerBasePath) {
                     // If we can't parse the full context, at least record the failure
                     try {
                         const basicStep = JSON.parse(match);
-                        if (basicStep.result === "failed" ||
-                            basicStep.result === "cancelled") {
+                        if (FAILURE_RESULT.test(basicStep.result)) {
                             failedSteps.push({
                                 result: basicStep.result,
                             });

--- a/src/__tests__/step-checker.test.ts
+++ b/src/__tests__/step-checker.test.ts
@@ -1,0 +1,60 @@
+import { promises as fs } from "fs";
+import * as os from "os";
+import * as path from "path";
+import { checkPreviousStepFailures } from "../step-checker";
+
+async function runnerWithWorkerLog(contents: string): Promise<string> {
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), "step-checker-"));
+  const diag = path.join(base, "_diag");
+  await fs.mkdir(diag);
+  await fs.writeFile(
+    path.join(diag, "Worker_20260805-000000-utc.log"),
+    contents,
+  );
+  return base;
+}
+
+describe("checkPreviousStepFailures", () => {
+  it('detects the runner\'s single-l "Canceled" spelling', async () => {
+    const base = await runnerWithWorkerLog("Step result: Canceled\n");
+    await expect(checkPreviousStepFailures(base)).resolves.toMatchObject({
+      hasFailures: true,
+    });
+  });
+
+  it("detects a canceled result in JSON form", async () => {
+    const base = await runnerWithWorkerLog('{"result": "canceled"}\n');
+    await expect(checkPreviousStepFailures(base)).resolves.toMatchObject({
+      hasFailures: true,
+    });
+  });
+
+  it("still detects the double-l spelling", async () => {
+    const base = await runnerWithWorkerLog("Step result: Cancelled\n");
+    await expect(checkPreviousStepFailures(base)).resolves.toMatchObject({
+      hasFailures: true,
+    });
+  });
+
+  it("still detects failures", async () => {
+    const base = await runnerWithWorkerLog("Step result: Failed\n");
+    await expect(checkPreviousStepFailures(base)).resolves.toMatchObject({
+      hasFailures: true,
+    });
+  });
+
+  it("reports no failures for a clean run", async () => {
+    const base = await runnerWithWorkerLog("Step result: Succeeded\n");
+    await expect(checkPreviousStepFailures(base)).resolves.toMatchObject({
+      hasFailures: false,
+      failedCount: 0,
+    });
+  });
+
+  it("reports an error when no worker log exists", async () => {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), "step-checker-"));
+    const result = await checkPreviousStepFailures(base);
+    expect(result.hasFailures).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/src/step-checker.ts
+++ b/src/step-checker.ts
@@ -2,6 +2,10 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import * as core from "@actions/core";
 
+// The runner's TaskResult enum spells it "Canceled", not "Cancelled", so a cancelled step
+// was read as a clean run. Accept either spelling, and any casing.
+const FAILURE_RESULT = /^(?:failed|cancell?ed)$/i;
+
 interface StepFailureCheck {
   hasFailures: boolean;
   failedCount: number;
@@ -88,10 +92,8 @@ export async function checkPreviousStepFailures(
 
     // Patterns to match failed or cancelled steps
     const failurePatterns = [
-      /"result":\s*"failed"/g,
-      /"result":\s*"cancelled"/g,
-      /Step result:\s*Failed/g,
-      /Step result:\s*Cancelled/g,
+      /"result":\s*"(?:failed|cancell?ed)"/gi,
+      /Step result:\s*(?:failed|cancell?ed)/gi,
     ];
 
     // Count total failures
@@ -108,7 +110,7 @@ export async function checkPreviousStepFailures(
 
     // Regex to extract JSON objects containing step information
     const jsonStepPattern =
-      /\{[^{}]*"result":\s*"(?:failed|cancelled)"[^{}]*\}/g;
+      /\{[^{}]*"result":\s*"(?:failed|cancell?ed)"[^{}]*\}/gi;
     const jsonMatches = logContent.match(jsonStepPattern);
 
     if (jsonMatches) {
@@ -126,10 +128,7 @@ export async function checkPreviousStepFailures(
             const contextJson = logContent.substring(contextStart, contextEnd);
             const stepData = JSON.parse(contextJson);
 
-            if (
-              stepData.result === "failed" ||
-              stepData.result === "cancelled"
-            ) {
+            if (FAILURE_RESULT.test(stepData.result)) {
               failedSteps.push({
                 action: stepData.action,
                 stepName: stepData.stepName || stepData.displayName,
@@ -142,10 +141,7 @@ export async function checkPreviousStepFailures(
           // If we can't parse the full context, at least record the failure
           try {
             const basicStep = JSON.parse(match);
-            if (
-              basicStep.result === "failed" ||
-              basicStep.result === "cancelled"
-            ) {
+            if (FAILURE_RESULT.test(basicStep.result)) {
               failedSteps.push({
                 result: basicStep.result,
               });


### PR DESCRIPTION
Fixes #69.

## Problem

A cancelled job commits its sticky disk, so a run killed part-way through publishes a partial disk as the snapshot later consumers mount. The post step is meant to catch this, and reports the opposite:

```
Checking for previous step failures before committing sticky disk
No previous step failures detected, committing sticky disk
```

That is from a run cancelled four minutes into a build. With `cancel-in-progress: true` it is routine — 41 of the last 100 default-branch runs in one repository were cancelled by the next merge.

## Cause

`src/step-checker.ts` matches `Cancelled`. The runner writes `Canceled`, per [`TaskResult.cs`](https://github.com/actions/runner/blob/main/src/Sdk/DTWebApi/WebApi/TaskResult.cs). `Failed` is spelled the same either way, so failed jobs do skip the commit and only cancellations slip through — which is why the guard looks like it works.

## Fix

The Worker log is runner-internal and does not appear in job logs, so the casing it uses cannot be confirmed from outside. The patterns accept either spelling and any casing rather than swapping one for the other:

```js
const failurePatterns = [
  /"result":\s*"(?:failed|cancell?ed)"/gi,
  /Step result:\s*(?:failed|cancell?ed)/gi,
];
```

Matching too broadly is the safer error here: a false positive skips one commit, a false negative publishes a corrupt snapshot.

## Validation

`src/__tests__/step-checker.test.ts` is new — `checkPreviousStepFailures` had no coverage. Against `main` it fails on exactly the two `Canceled` cases and passes on the double-l spelling, on `Failed`, on a clean run, and on a missing Worker log. All six pass with the fix. Full suite 10/10, `npm run lint` clean, `npm run format` a no-op.

`npm ci` returns 404 for `@buf/blacksmith_vm-agent.connectrpc_es` and `@buf/blacksmith_vm-agent.bufbuild_es`, so `dist/post/index.js` was regenerated by stubbing the single symbol `src/utils.ts` imports from them and running the real `ncc`. On unmodified `main` that produces a `step-checker` module byte-identical to the committed bundle, and on this branch it matches the region committed here. `step-checker` is the only changed module, and `dist/index.js` does not contain it.

## Questions

**Is a sample Worker log available?** With one, the patterns could be narrowed to the exact string rather than a family of spellings, on a path that decides whether a commit is safe.

**Is there a route to those two `@buf` packages for outside contributors?** `CLAUDE.md` asks contributors to run `npm run build` and stage `dist/`, which needs them. Not a blocker for this PR — the bundle is verified above — but it would make that step reproducible.
